### PR TITLE
Fix mobile formatting: card layout + topbar overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@ body{font-family:var(--ff);background:var(--bg);color:var(--text);min-height:100
   display:flex; align-items:center; justify-content:space-between;
   padding:0 28px; height:54px; gap:16px; position:sticky; top:0; z-index:10;
 }
-.brand{display:flex;align-items:center;gap:10px;font-size:16px;font-weight:700;letter-spacing:-.3px;color:var(--text)}
+.brand{display:flex;align-items:center;gap:10px;font-size:16px;font-weight:700;letter-spacing:-.3px;color:var(--text);white-space:nowrap}
 .brand-dot{width:9px;height:9px;border-radius:50%;background:var(--green);box-shadow:0 0 7px var(--green);flex-shrink:0}
 .topbar-right{display:flex;align-items:center;gap:10px}
 .topbar-date{font-size:12px;color:var(--text2);font-family:var(--ffm)}
@@ -63,6 +63,7 @@ body{font-family:var(--ff);background:var(--bg);color:var(--text);min-height:100
   background:var(--green);color:#071a0e;
   border:none;border-radius:7px;padding:7px 16px;cursor:pointer;
   display:flex;align-items:center;gap:5px;transition:opacity .15s,transform .1s;
+  white-space:nowrap;flex-shrink:0;
 }
 .btn-add:hover{opacity:.85}
 .btn-add:active{transform:scale(.97)}
@@ -71,6 +72,7 @@ body{font-family:var(--ff);background:var(--bg);color:var(--text);min-height:100
   padding:6px 11px;border:1px solid var(--border2);border-radius:7px;
   background:transparent;color:var(--text2);cursor:pointer;
   display:flex;align-items:center;gap:4px;transition:all .12s;
+  white-space:nowrap;flex-shrink:0;
 }
 .btn-ghost:hover{background:var(--panel2);color:var(--text)}
 
@@ -229,10 +231,64 @@ tbody tr:hover{background:rgba(255,255,255,.022)}
 .modal-section{font-size:10px;font-weight:700;color:var(--text3);text-transform:uppercase;letter-spacing:.8px;margin:16px 0 10px;padding-bottom:6px;border-bottom:1px solid var(--border)}
 
 @media(max-width:700px){
+  /* ── layout ── */
   .kpi-row{grid-template-columns:repeat(2,1fr)}
   .page{padding:14px 14px 32px}
-  .tbl-tools .filter-tabs{display:none}
+  /* ── topbar ── */
   .topbar-user{display:none}
+  .topbar-date{display:none}
+  .topbar{padding:8px;gap:6px;height:auto}
+  .brand{font-size:14px}
+  .btn-add{font-size:12px;padding:6px 10px}
+  /* ── modal ── */
+  .f2{grid-template-columns:1fr}
+  .modal{padding:1.25rem}
+  /* ── search ── */
+  .search-input{width:120px}
+  .search-input:focus{width:150px}
+
+  /* ── card layout: convert table rows into cards ── */
+  .tbl-wrap{border:none;background:transparent}
+  table{display:block;width:100%;min-width:unset}
+  thead{display:none}
+  tbody{display:flex;flex-direction:column;gap:10px}
+  tbody tr{
+    display:grid;
+    grid-template-columns:1fr auto;
+    grid-template-rows:auto auto auto auto;
+    background:var(--panel);
+    border:1px solid var(--border);
+    border-radius:10px;
+    overflow:hidden;
+  }
+  tbody tr:hover{background:var(--panel)}
+  tbody td{padding:0;border-bottom:none;overflow:visible;vertical-align:unset}
+
+  /* row 1: name (left) + status (right) */
+  tbody td:nth-child(1){grid-column:1;grid-row:1;padding:14px 0 0 14px}
+  tbody td:nth-child(2){grid-column:2;grid-row:1;padding:14px 14px 0 8px;align-self:start}
+
+  /* row 2: pills full width */
+  tbody td:nth-child(3){grid-column:1/-1;grid-row:2;padding:10px 14px 0}
+
+  /* row 3: refill date + pharmacy */
+  tbody td:nth-child(4){grid-column:1;grid-row:3;padding:10px 8px 14px 14px}
+  tbody td:nth-child(5){grid-column:2;grid-row:3;padding:10px 14px 14px 8px;text-align:right}
+  tbody td:nth-child(4)::before{content:'Refill';display:block;font-size:10px;font-weight:700;color:var(--text3);text-transform:uppercase;letter-spacing:.6px;margin-bottom:2px}
+  tbody td:nth-child(5)::before{content:'Pharmacy';display:block;font-size:10px;font-weight:700;color:var(--text3);text-transform:uppercase;letter-spacing:.6px;margin-bottom:2px;text-align:right}
+
+  /* row 4: action buttons */
+  tbody td:nth-child(6){
+    grid-column:1/-1;grid-row:4;
+    display:flex;justify-content:flex-end;gap:8px;
+    padding:10px 14px;
+    border-top:1px solid var(--border);
+  }
+  .act{padding:7px 16px;font-size:13px}
+
+  /* empty state */
+  .empty-row{display:block}
+  .empty-row td{display:block;grid-column:1/-1;padding:2rem!important;text-align:center}
 }
 @media print{
   .topbar .btn-add,.td-act,.tbl-tools{display:none!important}


### PR DESCRIPTION
## Summary
- Converts the medication table into stacked cards on mobile (<700px) — all data visible with no horizontal scrolling
- Fixes topbar overflow: brand text and buttons no longer wrap on small screens
- Stacks modal form fields to a single column on mobile for easier input

## Changes
- `white-space:nowrap` + `flex-shrink:0` on `.brand`, `.btn-add`, `.btn-ghost` to prevent text wrapping
- Mobile topbar: reduced padding, hidden date label, smaller font/button sizes
- Card layout via CSS grid on `<tr>` elements — name/status top row, pills bar middle, refill+pharmacy bottom, actions footer
- Modal `.f2` grid collapses to single column on mobile
- Removed dead `.tbl-tools .filter-tabs` selector (tabs live in `.tbl-left`)

## Test plan
- [ ] Open on a mobile device or browser devtools at 375px width
- [ ] Verify topbar fits on one line
- [ ] Verify medication cards show all data without horizontal scroll
- [ ] Verify desktop table layout is unchanged above 700px
- [ ] Verify add/edit modal fields stack vertically on mobile

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)