### PR TITLE
Add appointments tracking with agenda view, mini calendar, and bulk i…

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,6 +25,8 @@ getRedirectResult(auth).catch(() => {});
 
 // ── STATE ──
 let meds = [], filter = 'all', editId = null, unsubMeds = null;
+let apts = [], editAptId = null, unsubApts = null;
+let activeTab = 'meds', calYear, calMonth;
 const $ = id => document.getElementById(id);
 
 // ── AUTH STATE ──
@@ -34,11 +36,14 @@ onAuthStateChanged(auth, user => {
     $('app').style.display = '';
     $('user-email').textContent = user.email;
     startMedsListener();
+    startAptsListener();
+    initCal();
   } else {
     $('login-screen').style.display = 'flex';
     $('app').style.display = 'none';
     if (unsubMeds) { unsubMeds(); unsubMeds = null; }
-    meds = [];
+    if (unsubApts) { unsubApts(); unsubApts = null; }
+    meds = []; apts = [];
   }
 });
 
@@ -234,7 +239,7 @@ function openModal(id){
 }
 function closeModal(){ $('modal').style.display='none'; editId=null; }
 function bgClick(e){ if(e.target===$('modal')) closeModal(); }
-document.addEventListener('keydown',e=>{ if(e.key==='Escape') closeModal(); });
+document.addEventListener('keydown',e=>{ if(e.key==='Escape'){ closeModal(); closeAptModal(); } });
 
 // ── CRUD → FIRESTORE ──
 async function saveMed(){
@@ -331,9 +336,448 @@ function dl(name,content,type){
   a.download=name; a.click(); URL.revokeObjectURL(a.href);
 }
 
+// ── APPOINTMENTS: FIRESTORE LISTENER ──
+function startAptsListener() {
+  if (unsubApts) unsubApts();
+  unsubApts = onSnapshot(collection(db, 'appointments'), snap => {
+    apts = snap.docs.map(d => d.data());
+    renderApts();
+  }, err => { console.error('Appointments Firestore error:', err); });
+}
+
+// ── APPOINTMENTS: TAB SWITCHING ──
+function switchTab(tab) {
+  activeTab = tab;
+  $('tab-meds').classList.toggle('active', tab === 'meds');
+  $('tab-apts').classList.toggle('active', tab === 'apts');
+  $('view-meds').style.display = tab === 'meds' ? '' : 'none';
+  $('view-apts').style.display = tab === 'apts' ? 'block' : 'none';
+  $('add-btn').textContent = tab === 'meds' ? '＋ Add medication' : '＋ Add appointment';
+}
+
+function handleAddBtn() {
+  if (activeTab === 'apts') openAptModal();
+  else openModal();
+}
+
+// ── APPOINTMENTS: HELPERS ──
+function aptStatus(a) {
+  const dt = new Date(a.dateTime);
+  const t = today();
+  const todayEnd = new Date(t); todayEnd.setHours(23,59,59,999);
+  const weekEnd  = new Date(t); weekEnd.setDate(t.getDate() + 7);
+  if (dt < t) return 'past';
+  if (dt <= todayEnd) return 'today';
+  if (dt <= weekEnd)  return 'soon';
+  return 'upcoming';
+}
+
+function fmtAptDateTime(str) {
+  if (!str) return '';
+  const d = new Date(str);
+  const timePart = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  const dayPart  = d.toLocaleDateString('en-US', { weekday: 'long' });
+  return `${timePart} · ${dayPart}`;
+}
+
+function fmtAptDateBlock(str) {
+  if (!str) return { month: '—', day: '—' };
+  const d = new Date(str);
+  return {
+    month: d.toLocaleDateString('en-US', { month: 'short' }),
+    day:   d.getDate()
+  };
+}
+
+function fmtAptTime(str) {
+  if (!str) return '';
+  const d = new Date(str);
+  // If time is midnight (00:00), treat as all-day — show no time
+  if (d.getHours() === 0 && d.getMinutes() === 0) return '';
+  return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+}
+
+function coveringLabel(c) {
+  return { fanuel: 'Fanuel', saron: 'Saron', both: 'Both', tbd: 'TBD' }[c] || 'TBD';
+}
+
+function typeLabel(t) {
+  return { checkup: 'Checkup', specialist: 'Specialist', lab: 'Lab', imaging: 'Imaging', other: 'Other' }[t] || '';
+}
+
+// ── APPOINTMENTS: RENDER ──
+function renderApts() {
+  const q = ($('apt-search')?.value || '').toLowerCase();
+  const now2 = new Date();
+
+  let rows = [...apts].filter(a =>
+    !q ||
+    (a.title||'').toLowerCase().includes(q) ||
+    (a.doctor||'').toLowerCase().includes(q) ||
+    (a.location||'').toLowerCase().includes(q)
+  ).sort((a, b) => new Date(a.dateTime) - new Date(b.dateTime));
+
+  const grouped = { today: [], soon: [], upcoming: [], past: [] };
+  rows.forEach(a => grouped[aptStatus(a)].push(a));
+
+  // Hero card — first non-past appointment
+  const nextApt = grouped.today[0] || grouped.soon[0] || grouped.upcoming[0] || null;
+  const heroEl = $('apt-hero');
+  if (nextApt) {
+    const s = aptStatus(nextApt);
+    const db2 = fmtAptDateBlock(nextApt.dateTime);
+    const time = fmtAptTime(nextApt.dateTime);
+    const timeLine = [time, new Date(nextApt.dateTime).toLocaleDateString('en-US',{weekday:'long'})].filter(Boolean).join(' · ');
+    const meta = [nextApt.doctor, nextApt.location].filter(Boolean).join(' · ');
+    const cov  = nextApt.covering;
+    const covHtml = cov ? `<span class="covering-pill ${esc(cov)}">${esc(coveringLabel(cov))}</span>` : '';
+    heroEl.innerHTML = `
+      <div class="hero-card ${s}" onclick="toggleHeroCard()" style="cursor:pointer;flex-wrap:wrap" id="hero-card-el">
+        <div style="display:flex;align-items:center;gap:20px;width:100%">
+          <div class="hero-date-block">
+            <div class="hero-date-month">${esc(db2.month)}</div>
+            <div class="hero-date-day">${db2.day}</div>
+          </div>
+          <div class="hero-body">
+            <div class="hero-card-label">Next appointment</div>
+            <div class="hero-card-title">${esc(nextApt.title)}</div>
+            ${timeLine ? `<div class="hero-card-time">${esc(timeLine)}</div>` : ''}
+            ${meta ? `<div class="hero-card-meta">${esc(meta)}</div>` : ''}
+            ${covHtml ? `<div style="margin-top:8px">${covHtml}</div>` : ''}
+          </div>
+          <span class="apt-chevron" id="hero-chevron">▼</span>
+        </div>
+        <div class="apt-expand" id="hero-expand">
+          <div class="apt-expand-grid">
+            <div>
+              <div class="expand-section-label">Prep &amp; questions</div>
+              ${nextApt.prep ? `<div class="expand-text">${esc(nextApt.prep)}</div>` : '<div class="expand-empty">None added</div>'}
+            </div>
+            <div>
+              <div class="expand-section-label">Post appointment notes</div>
+              ${nextApt.postNotes ? `<div class="expand-text">${esc(nextApt.postNotes)}</div>` : '<div class="expand-empty">None added</div>'}
+            </div>
+          </div>
+        </div>
+      </div>`;
+  } else {
+    heroEl.innerHTML = '';
+  }
+
+  // Agenda
+  const agendaEl = $('apt-agenda');
+  let html = '';
+
+  function aptCardHtml(a, statusClass) {
+    const db3 = fmtAptDateBlock(a.dateTime);
+    const time = fmtAptTime(a.dateTime);
+    const cov  = a.covering;
+    const covHtml = cov ? `<span class="covering-pill ${esc(cov)}">${esc(coveringLabel(cov))}</span>` : '';
+    const tl = typeLabel(a.type);
+    const metaParts = [
+      a.doctor   ? `<span class="apt-doctor">${esc(a.doctor)}</span>` : '',
+      a.doctor && a.location ? '<span class="apt-sep">·</span>' : '',
+      a.location ? `<span class="apt-location">${esc(a.location)}</span>` : '',
+      tl ? `<span class="type-chip">${esc(tl)}</span>` : '',
+    ].filter(Boolean).join('');
+
+    return `<div class="apt-card ${statusClass}" data-apt-id="${esc(a.id)}" onclick="toggleAptCard(this)">
+      <div class="apt-card-top">
+        <div class="apt-date">
+          <div class="apt-date-month">${esc(db3.month)}</div>
+          <div class="apt-date-day">${db3.day}</div>
+        </div>
+        <div class="apt-divider"></div>
+        <div class="apt-body">
+          <div class="apt-title">${esc(a.title)}</div>
+          ${time ? `<div class="apt-time">${esc(time)}</div>` : ''}
+          ${metaParts ? `<div class="apt-meta">${metaParts}</div>` : ''}
+        </div>
+        ${covHtml}
+        <div class="apt-actions" onclick="event.stopPropagation()">
+          <button class="act-icon" title="Edit" onclick="openAptModal('${esc(a.id)}')">✏</button>
+          <button class="act-icon del" title="Delete" onclick="delApt('${esc(a.id)}')">🗑</button>
+        </div>
+        <span class="apt-chevron">▼</span>
+      </div>
+      <div class="apt-expand">
+        <div class="apt-expand-grid">
+          <div>
+            <div class="expand-section-label">Prep &amp; questions</div>
+            ${a.prep ? `<div class="expand-text">${esc(a.prep)}</div>` : '<div class="expand-empty">None added</div>'}
+          </div>
+          <div>
+            <div class="expand-section-label">Post appointment notes</div>
+            ${a.postNotes ? `<div class="expand-text">${esc(a.postNotes)}</div>` : '<div class="expand-empty">None added</div>'}
+          </div>
+        </div>
+      </div>
+    </div>`;
+  }
+
+  // Today
+  if (grouped.today.length) {
+    const d = new Date(); const dateStr = d.toLocaleDateString('en-US',{month:'short',day:'numeric'});
+    html += `<div class="agenda-group"><div class="group-hdr">
+      <span class="group-label today-lbl">Today — ${dateStr}</span>
+      <div class="group-line"></div><span class="group-count">${grouped.today.length}</span>
+    </div>${grouped.today.map(a => aptCardHtml(a, 'today')).join('')}</div>`;
+  }
+
+  // This week
+  if (grouped.soon.length) {
+    const t2 = today();
+    const start = new Date(t2); start.setDate(t2.getDate() + 1);
+    const end   = new Date(t2); end.setDate(t2.getDate() + 7);
+    const range = `${start.toLocaleDateString('en-US',{month:'short',day:'numeric'})}–${end.toLocaleDateString('en-US',{month:'short',day:'numeric'})}`;
+    html += `<div class="agenda-group"><div class="group-hdr">
+      <span class="group-label">This week — ${range}</span>
+      <div class="group-line"></div><span class="group-count">${grouped.soon.length}</span>
+    </div>${grouped.soon.map(a => aptCardHtml(a, 'soon')).join('')}</div>`;
+  }
+
+  // Upcoming
+  if (grouped.upcoming.length) {
+    html += `<div class="agenda-group"><div class="group-hdr">
+      <span class="group-label">Upcoming</span>
+      <div class="group-line"></div><span class="group-count">${grouped.upcoming.length}</span>
+    </div>${grouped.upcoming.map(a => aptCardHtml(a, 'upcoming')).join('')}</div>`;
+  }
+
+  // Past (collapsed)
+  if (grouped.past.length) {
+    const pastCards = [...grouped.past].reverse().map(a => aptCardHtml(a, 'past')).join('');
+    html += `<div class="agenda-group">
+      <button class="past-toggle" onclick="togglePastGroup(this)">
+        <span class="past-toggle-icon" id="past-toggle-icon">▼</span>
+        Show ${grouped.past.length} past appointment${grouped.past.length !== 1 ? 's' : ''}
+      </button>
+      <div class="past-content" id="past-content">
+        <div class="group-hdr" style="margin-top:10px">
+          <span class="group-label">Past</span>
+          <div class="group-line"></div><span class="group-count">${grouped.past.length}</span>
+        </div>
+        <div class="past-group-wrap">${pastCards}</div>
+      </div>
+    </div>`;
+  }
+
+  if (!html && apts.length === 0) {
+    html = `<div style="text-align:center;padding:3rem;color:var(--text2)">No appointments yet. Click "+ Add appointment" to get started.</div>`;
+  } else if (!html) {
+    html = `<div style="text-align:center;padding:3rem;color:var(--text2)">No appointments match your search.</div>`;
+  }
+
+  agendaEl.innerHTML = html;
+  renderCal();
+}
+
+// ── APPOINTMENTS: CARD EXPAND ──
+function toggleAptCard(card) {
+  const expand  = card.querySelector('.apt-expand');
+  const chevron = card.querySelector('.apt-chevron');
+  expand.classList.toggle('open');
+  chevron.classList.toggle('open');
+}
+
+function toggleHeroCard() {
+  $('hero-expand')?.classList.toggle('open');
+  $('hero-chevron')?.classList.toggle('open');
+}
+
+function togglePastGroup(btn) {
+  const content = btn.nextElementSibling;
+  const icon    = btn.querySelector('.past-toggle-icon');
+  const open    = content.classList.toggle('open');
+  icon.classList.toggle('open', open);
+  const n = content.querySelectorAll('.apt-card').length;
+  btn.childNodes[2].textContent = open
+    ? ' Hide past appointments'
+    : ` Show ${n} past appointment${n !== 1 ? 's' : ''}`;
+}
+
+// ── APPOINTMENTS: MINI CALENDAR ──
+function initCal() {
+  const now2 = new Date();
+  calYear  = now2.getFullYear();
+  calMonth = now2.getMonth();
+  renderCal();
+}
+
+function changeMonth(dir) {
+  calMonth += dir;
+  if (calMonth > 11) { calMonth = 0; calYear++; }
+  if (calMonth < 0)  { calMonth = 11; calYear--; }
+  renderCal();
+}
+
+function renderCal() {
+  const labelEl = $('cal-month-label');
+  const gridEl  = $('cal-days');
+  if (!labelEl || !gridEl) return;
+
+  labelEl.textContent = new Date(calYear, calMonth, 1)
+    .toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+
+  gridEl.innerHTML = '';
+  const now2       = new Date();
+  const firstDow   = new Date(calYear, calMonth, 1).getDay();
+  const daysInMonth = new Date(calYear, calMonth + 1, 0).getDate();
+
+  // Build a map: "YYYY-M-D" → assignee[]
+  const dotMap = {};
+  apts.forEach(a => {
+    if (!a.dateTime) return;
+    const d = new Date(a.dateTime);
+    const key = `${d.getFullYear()}-${d.getMonth()+1}-${d.getDate()}`;
+    if (!dotMap[key]) dotMap[key] = new Set();
+    const c = a.covering || 'tbd';
+    if (c === 'both') { dotMap[key].add('fanuel'); dotMap[key].add('saron'); }
+    else dotMap[key].add(c);
+  });
+
+  for (let i = 0; i < firstDow; i++) {
+    const el = document.createElement('div');
+    el.className = 'cal-day empty';
+    gridEl.appendChild(el);
+  }
+
+  for (let d = 1; d <= daysInMonth; d++) {
+    const key = `${calYear}-${calMonth+1}-${d}`;
+    const isToday = d === now2.getDate() && calMonth === now2.getMonth() && calYear === now2.getFullYear();
+    const assignees = dotMap[key];
+
+    const cell = document.createElement('div');
+    cell.className = 'cal-day' +
+      (isToday   ? ' today'   : '') +
+      (assignees ? ' has-apt' : '') +
+      (!isToday && calMonth < now2.getMonth() && calYear <= now2.getFullYear() ? ' faded' : '');
+
+    const num = document.createElement('div');
+    num.className = 'cal-day-num';
+    num.textContent = d;
+    cell.appendChild(num);
+
+    if (assignees) {
+      const dots = document.createElement('div');
+      dots.className = 'cal-dots';
+      assignees.forEach(a => {
+        const dot = document.createElement('div');
+        dot.className = `cal-dot ${a}`;
+        dots.appendChild(dot);
+      });
+      cell.appendChild(dots);
+      cell.onclick = () => calDayClick(calYear, calMonth + 1, d);
+    }
+
+    gridEl.appendChild(cell);
+  }
+}
+
+function calDayClick(year, month, day) {
+  // Find appointments on this date
+  const matches = apts.filter(a => {
+    if (!a.dateTime) return false;
+    const d = new Date(a.dateTime);
+    return d.getFullYear() === year && d.getMonth() + 1 === month && d.getDate() === day;
+  });
+  if (!matches.length) return;
+
+  // If any are past, expand the past group first
+  const hasPast = matches.some(a => aptStatus(a) === 'past');
+  if (hasPast) {
+    const pastContent = $('past-content');
+    const pastIcon    = document.querySelector('.past-toggle-icon');
+    const pastBtn     = document.querySelector('.past-toggle');
+    if (pastContent && !pastContent.classList.contains('open')) {
+      pastContent.classList.add('open');
+      if (pastIcon) pastIcon.classList.add('open');
+      if (pastBtn) {
+        const n = pastContent.querySelectorAll('.apt-card').length;
+        const textNode = pastBtn.childNodes[2];
+        if (textNode) textNode.textContent = ' Hide past appointments';
+      }
+    }
+  }
+
+  // Scroll to first matching card
+  const firstId = matches[0].id;
+  const card = document.querySelector(`[data-apt-id="${firstId}"]`);
+  if (card) card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+}
+
+// ── APPOINTMENTS: MODAL ──
+function openAptModal(id) {
+  editAptId = id || null;
+  const a = editAptId ? apts.find(x => x.id === editAptId) : {};
+  $('apt-modal-h').textContent = editAptId ? 'Edit appointment' : 'Add appointment';
+  $('apt-f-title').value     = a.title    || '';
+  $('apt-f-datetime').value  = a.dateTime || '';
+  $('apt-f-type').value      = a.type     || '';
+  $('apt-f-doctor').value    = a.doctor   || '';
+  $('apt-f-location').value  = a.location || '';
+  $('apt-f-covering').value  = a.covering || '';
+  $('apt-f-prep').value      = a.prep     || '';
+  $('apt-f-postnotes').value = a.postNotes|| '';
+  $('apt-modal').style.display = 'flex';
+  setTimeout(() => $('apt-f-title').focus(), 50);
+}
+
+function closeAptModal() {
+  $('apt-modal').style.display = 'none';
+  editAptId = null;
+}
+
+function aptBgClick(e) {
+  if (e.target === $('apt-modal')) closeAptModal();
+}
+
+
+// ── APPOINTMENTS: CRUD ──
+async function saveApt() {
+  const title    = $('apt-f-title').value.trim();
+  const dateTime = $('apt-f-datetime').value;
+  if (!title)    { alert('Please enter the appointment title.'); return; }
+  if (!dateTime) { alert('Please enter the date and time.'); return; }
+
+  const apt = {
+    id:        editAptId || Date.now().toString(36) + Math.random().toString(36).slice(2),
+    title,
+    dateTime,
+    type:      $('apt-f-type').value,
+    doctor:    $('apt-f-doctor').value.trim(),
+    location:  $('apt-f-location').value.trim(),
+    covering:  $('apt-f-covering').value,
+    prep:      $('apt-f-prep').value.trim(),
+    postNotes: $('apt-f-postnotes').value.trim(),
+    updatedAt: new Date().toISOString()
+  };
+
+  try {
+    await setDoc(doc(db, 'appointments', apt.id), apt);
+    closeAptModal();
+  } catch(e) {
+    alert('Failed to save. Please check your connection and try again.');
+    console.error(e);
+  }
+}
+
+async function delApt(id) {
+  const a = apts.find(x => x.id === id); if (!a) return;
+  if (!confirm(`Remove "${a.title}"?`)) return;
+  try {
+    await deleteDoc(doc(db, 'appointments', id));
+  } catch(e) {
+    alert('Failed to delete. Please check your connection and try again.');
+    console.error(e);
+  }
+}
+
 // ── EXPOSE TO HTML ONCLICK HANDLERS ──
 Object.assign(window, {
   login, logout, openModal, closeModal, bgClick, saveMed,
   delMed, markRefilled, exportCSV, exportJSON, importJSON,
-  handleImport, setFilter, render
+  handleImport, setFilter, render,
+  switchTab, handleAddBtn, openAptModal, closeAptModal, aptBgClick,
+  saveApt, delApt, changeMonth, toggleAptCard, toggleHeroCard, togglePastGroup, calDayClick
 });

--- a/bulk-import-apts.html
+++ b/bulk-import-apts.html
@@ -1,0 +1,424 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Bulk Import — Appointments</title>
+<style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{font-family:system-ui,sans-serif;background:#0F1117;color:#E8EAF0;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:2rem}
+  .card{background:#181B23;border:1px solid rgba(255,255,255,.13);border-radius:13px;padding:2rem;width:100%;max-width:500px;text-align:center}
+  h1{font-size:18px;font-weight:700;margin-bottom:.5rem}
+  p{font-size:13px;color:#8B8FA8;margin-bottom:1.5rem;line-height:1.6}
+  .btn{font-size:14px;font-weight:600;padding:10px 24px;border-radius:8px;border:none;cursor:pointer;transition:opacity .15s;margin:6px}
+  .btn-primary{background:#3DD68C;color:#071a0e}
+  .btn-primary:hover{opacity:.85}
+  .btn-primary:disabled{opacity:.4;cursor:not-allowed}
+  .btn-secondary{background:transparent;color:#8B8FA8;border:1px solid rgba(255,255,255,.13)}
+  .btn-secondary:hover{background:#1E2230}
+  .status{margin-top:1.25rem;font-size:13px;color:#8B8FA8;min-height:24px;font-family:monospace;line-height:1.7;text-align:left;background:#0F1117;border-radius:8px;padding:12px;display:none}
+  .status.active{display:block}
+  .done{color:#3DD68C;font-weight:600}
+  .err{color:#FF5C5C}
+  #user-row{font-size:12px;color:#555870;margin-bottom:1rem;min-height:16px}
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>Appointment Bulk Import</h1>
+  <p>This will import <strong>38 past appointments</strong> into Firestore.<br>Sign in first, then click Import.</p>
+  <div id="user-row"></div>
+  <button class="btn btn-secondary" id="sign-in-btn" onclick="doSignIn()">Sign in with Google</button>
+  <button class="btn btn-primary" id="import-btn" onclick="doImport()" disabled>Import 38 appointments</button>
+  <div class="status" id="status"></div>
+</div>
+
+<script type="module">
+import { initializeApp }                                     from 'https://www.gstatic.com/firebasejs/10.14.1/firebase-app.js';
+import { getAuth, GoogleAuthProvider, signInWithPopup,
+         onAuthStateChanged }                                from 'https://www.gstatic.com/firebasejs/10.14.1/firebase-auth.js';
+import { getFirestore, collection, doc, setDoc }             from 'https://www.gstatic.com/firebasejs/10.14.1/firebase-firestore.js';
+
+const firebaseConfig = {
+  apiKey:            "AIzaSyCD1uMNkBMdbArrv4zKppc54Lgxg66xMdo",
+  authDomain:        "dad-med-tracker.firebaseapp.com",
+  projectId:         "dad-med-tracker",
+  storageBucket:     "dad-med-tracker.firebasestorage.app",
+  messagingSenderId: "1043260614123",
+  appId:             "1:1043260614123:web:352f4cfa5ee621f22425ae"
+};
+
+const app  = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+const db   = getFirestore(app);
+const provider = new GoogleAuthProvider();
+
+onAuthStateChanged(auth, user => {
+  const row = document.getElementById('user-row');
+  const btn = document.getElementById('import-btn');
+  const signInBtn = document.getElementById('sign-in-btn');
+  if (user) {
+    row.textContent = '✓ Signed in as ' + user.email;
+    btn.disabled = false;
+    signInBtn.style.display = 'none';
+  } else {
+    row.textContent = '';
+    btn.disabled = true;
+    signInBtn.style.display = '';
+  }
+});
+
+window.doSignIn = async () => {
+  try { await signInWithPopup(auth, provider); } catch(e) { console.error(e); }
+};
+
+const TS = new Date().toISOString();
+
+const APPOINTMENTS = [
+  {
+    id:'imp-001', title:'Liver Consultants — Initial Visit',
+    dateTime:'2024-10-29T12:15', doctor:'Dr. Amar Mahgoub',
+    location:'Liver Consultants of Texas', type:'specialist', covering:'tbd',
+    prep:'Questions:\n- Status of pain (2–3/10 sitting, 6–7/10 sleeping on side, 4–5/10 chest pain)\n- Blood still in abdomen? Next steps?\n- Current cancer stage and spread\n- Calcium buildup in artery (cardiologist referral from Dr. Reddy)',
+    postNotes:'Weight 139 lbs, BP 105/64\nFirst meeting with Mahgoub. Reviewed overall liver and cancer status.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-002', title:'Oncology — Immunotherapy #1',
+    dateTime:'2024-11-11T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Weight 140.8 lbs, BP 124/70, Temp 98.5, HR 67\nFirst immunotherapy session. 1 dose of 2 drugs via IV. No pre-medication. Every 4 weeks.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-003', title:'Oncology — Immunotherapy #2',
+    dateTime:'2024-12-09T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'Dad feeling anxious/breathing heavily, poor sleep, very fatigued. Request dietitian referral.',
+    postNotes:'Weight 136.8 lbs, BP 134/70\nLabs + Abushahin appt + immunotherapy completed. New narco prescription.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-004', title:'Psychiatry — Follow Up',
+    dateTime:'2024-12-11T11:00', doctor:'Dr. Humaira Khalid',
+    location:'', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Prescribed: Cymbalta 20mg (×2), Remeron 15mg at bedtime. Follow up in 1 month.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-005', title:'Oncology — Immunotherapy #3',
+    dateTime:'2025-01-06T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Spoke with dietician. Increase caloric intake recommended.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-006', title:'Psychiatry — Follow Up',
+    dateTime:'2025-01-08T11:00', doctor:'Dr. Humaira Khalid',
+    location:'', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Dad sleeping 3–4 hrs/night max. Remeron increased to 30mg. Call if no improvement in 10 days. May add Seroquel next. Cymbalta same dosage. Next appt 02/05 11AM.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-007', title:'Oncology — Immunotherapy #4',
+    dateTime:'2025-02-03T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Weight 141 lbs, BP 110/60\nDad mentioned pain in a specific spot on belly.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-008', title:'Psychiatry — Follow Up',
+    dateTime:'2025-02-05T11:00', doctor:'Dr. Humaira Khalid',
+    location:'', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Everything went well. Dad gave update on immunotherapy. Continue Seroquel and Remeron same dosage. Next appt April 30 at 11am.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-009', title:'Hepatology — Liver Follow Up',
+    dateTime:'2025-02-17T10:00', doctor:'Dr. Amar Mahgoub',
+    location:'Liver Consultants of Texas', type:'specialist', covering:'tbd',
+    prep:'Questions:\n- Status of liver?\n- Plan to address liver issues?\n- Continue acid medication?\n- Share abdomen pain on right side (1+ month)',
+    postNotes:'Temp 97.9, BP 119/69, HR 72\n\n1. Cymbalta is hard on liver — Mahgoub asked psychiatrist to wean off or switch to gabapentin/lyrica.\n2. Starting Entecavir (Baraclude) to prevent Hep B flare-up — must continue indefinitely.\n3. Abdomen pain on right side: likely procedure, constipation, or chemo side effect. Use heating pad or Icy Hot.\n4. Liver transplant earliest discussion: Sept/Oct 2025 after 1 year of treatment with no cancer evidence.\n\nNext appt: May 19 at 11:30am.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-010', title:'Nephrology — Kidney Follow Up',
+    dateTime:'2025-02-25T10:00', doctor:'Dr. Deeba Ali',
+    location:'', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Blood work and urine test results good. Kidney functioning well, no complications. Doc concerned about weight loss (138.6 lbs). Next appt in 6 months.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-011', title:'Oncology — Immunotherapy #5',
+    dateTime:'2025-03-03T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Weight 137.5 lbs (4 lbs less than last appt).\nClarified Mahgoub vs. Gupta confusion — Dad continuing with Abushahin for immunotherapy through rest of year, possibly longer.\nCT scan to be scheduled before or day of next immunotherapy.\nNext appt: 03/31 8:20am.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-012', title:'Oncology — Immunotherapy #6',
+    dateTime:'2025-03-31T08:20', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Blood work normal. CT scan normal except back of abdomen (near pancreas) showing inflammation — lighter spot of unknown cause (cancer cells vs. chemo side effect).\nAbushahin recommending advanced endoscopy biopsy. Will call Mahgoub to arrange.\nNext immunotherapy #7: April 28, labs 8:30AM, appt 9AM.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-013', title:'Oncology — Immunotherapy #7',
+    dateTime:'2025-04-28T08:30', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Labs 8:30AM, Abushahin 9AM.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-014', title:'Psychiatry — Follow Up',
+    dateTime:'2025-04-30T11:00', doctor:'Dr. Humaira Khalid',
+    location:'', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Follow up from Feb 5 appointment.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-015', title:'Hepatology — Liver Follow Up',
+    dateTime:'2025-05-19T11:30', doctor:'Dr. Amar Mahgoub',
+    location:'Liver Consultants of Texas', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Weight 134.3 lbs. Overall numbers look good. WBC high 5% from 4/28 scan. Tissue looking different. During open enrollment, check that transplant is added.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-016', title:'Oncology — Immunotherapy + May Scan Recap',
+    dateTime:'2025-05-28T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'May scan results:\n- Original liver area (where it ruptured): smaller vs March — immunotherapy likely working.\n- Back of abdomen tissue: worse vs March and vs October. More bulky/prominent. Unknown — could be cancer or treatment side effect. Tissue is between organs, hard to reach (vein blocking).\n\nNext steps:\n- Gupta to be consulted on how to sample the tissue\n- Additional blood work ordered (tumor markers)\n\nSymptoms to watch: loose stool, diarrhea, swelling legs/abdomen, intense back pain.\nNext immunotherapy: 06/25 8AM labs, 9AM Laith.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-017', title:'Surgery Consult — Laparoscopy Planning (Gupta)',
+    dateTime:'2025-05-29T10:00', doctor:'Dr. Amar Gupta',
+    location:'', type:'specialist', covering:'tbd',
+    prep:'Questions:\n- How long is the procedure?\n- What are the risks?\n- What is the goal?\n- Who performs it?\n- When is it scheduled?\n- Post-procedure recovery?\n- Next steps after procedure — Gupta or Abushahin?',
+    postNotes:'Gupta consulted with Abushahin on May scan. Excisional lymph node biopsy planned to sample tissue in back of abdomen. Gupta nurse Megan called same day to schedule. Procedure: less than 1 hour.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-018', title:'Surgery — Excisional Lymph Node Biopsy (Gupta)',
+    dateTime:'2025-06-11T08:00', doctor:'Dr. Amar Gupta',
+    location:'', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Excisional lymph node biopsy completed. 8AM check-in.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-019', title:'Post-Op Follow Up (Gupta)',
+    dateTime:'2025-06-24T10:00', doctor:'Dr. Amar Gupta',
+    location:'', type:'specialist', covering:'tbd',
+    prep:'Questions:\n1. Can dad mow grass without harming incisions?\n2. Why did lymph node size increase — will it continue?',
+    postNotes:'Weight 131.2 lbs, Temp 98.8\n\nGupta confirmed: sample from lymph node near pancreas is cancerous — same liver cancer cells. Not a different cancer type.\nGupta did not remove full lymph node — too invasive; goal was biopsy only.\nCannot rule out spread to other areas (only visible once large enough on scan).\nGupta informed Abushahin day of surgery.\n\nNext steps: Abushahin to discuss treatment options at next appointment.\n\nHealing instructions: eat/drink, keep clean, don\'t pick the glue off.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-020', title:'Oncology — Cabometyx Prescribed',
+    dateTime:'2025-06-25T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Dad prescribed Cabometyx 40mg sample (15 days). Stopped Tibsovo per Abushahin.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-021', title:'Oncology — Cabometyx Check-In',
+    dateTime:'2025-07-03T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'Questions:\n- Weight going down — speak with dietitian?\n- Cabometyx 40mg (15 tablets): how long? How to get more? Food restrictions (grape, grapefruit, star fruit)?\n- Blood pressure machine error',
+    postNotes:'Weight 128.2 lbs, BP 133/71, Temp 98.3, Pain 4–5/10\nPA: Erica\n\nNext steps:\n- Telehealth with Leah or Morgan (dietician) at next appt\n- Pharmacy to confirm if Cabometyx timing can move to earlier morning\n- Next Abushahin appt: 7/17\n- 60mg sample sent to 3rd floor pharmacy\n- Imodium (OTC) for diarrhea as needed',
+    updatedAt:TS
+  },
+  {
+    id:'imp-022', title:'Oncology — Cabometyx + Tibsovo Discussion',
+    dateTime:'2025-09-09T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'Topics:\n- Abdominal pain 6–7/10, lower ribs, lower back\n- Diarrhea continuing\n- Metal taste (Cabometyx side effect)\n- Amlodipine update from kidney/PCP — stopping until weight up',
+    postNotes:'Weight 124.8 lbs, BP 119/67\nNurse: Sheri Zadina\n\nAbushahin thinks Cabometyx may not be working given pain. Requesting Tibsovo (insurance may push back). Continue Cabometyx until Tibsovo ready.\nTibsovo targets IDH-1 mutation in liver/bile duct cancer.\n\nNext appt: 9/17 8AM labs + Abushahin. Dietician to visit.\nCT scan scheduled for week of Sept 20.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-023', title:'Oncology — CT Scan + Tibsovo Start',
+    dateTime:'2025-09-17T08:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Weight 122.8 lbs, BP 128/68\nTibsovo medication ready to pick up. Dad stopped Cabometyx.\nNutritional consult with Leah Wilson (dietician) — handout sent to dad\'s email.\nCT Scan done (1st floor, suite 150).\nEKG to be scheduled — scheduling will call Fanuel.\nNext Abushahin appt: September 29 10AM.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-024', title:'Oncology — Scan Results Review',
+    dateTime:'2025-09-29T10:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'Questions:\n1. Sept 17 scan results (size?)\n2. Continuous abdominal pain 6–7/10\n3. Tramadol not effective — alternatives besides oxycodone?\n4. Tibsovo timing — when to take, with food?\n5. Dietician update',
+    postNotes:'Weight 121.2 lbs, Temp 98.1\n\nScan results (9/17): Slightly larger than August (10%). Liver same. Soft tissue 6.23×3.7 (Sept) vs 5.5×3.1 (Aug). Another area in abdomen being monitored.\nMet with dietician Morgan.\nOxycodone prescribed (every 6 hrs as needed) + Senakot morning & night for constipation.\nAbushahin: stop Lisinopril — monitor BP (150+ → resume).\nTibsovo: can be taken with food.\nNext scan: late October.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-025', title:'Oncology — Tibsovo Check-In',
+    dateTime:'2025-10-14T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'Questions:\n1. When will next scan be scheduled?\n2. Next step if Tibsovo isn\'t working?',
+    postNotes:'Weight 120.6 lbs, BP 131/76\n\nScan scheduled for end of October + same-day Abushahin appt.\nIf Tibsovo not working, will consider medication in same category as Cabometyx.\nAbushahin optimistic about next scan.\nDietician: Increase Kate Farms Peptide to 1.5–2/day. Can run through insurance.\nTibsovo: 50g fat limit — whole milk from Silk is fine.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-026', title:'Oncology — CT Scan Results (Oct)',
+    dateTime:'2025-10-29T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'Questions:\n- Follow up on CT scan from morning\n- Update on peptide through insurance from dietician',
+    postNotes:'Weight 120.4 lbs, BP 146/76\n\nCT Scan results: Size 6.0×3.5 (was 6.2×3.7 — slightly smaller).\nCreon prescribed — pancreatic enzyme taken during each meal.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-027', title:'Labs — Blood Work',
+    dateTime:'2025-11-24T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'lab', covering:'tbd',
+    prep:'',
+    postNotes:'Weight 121 lbs. Blood work went well. Scan planned for 3 weeks.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-028', title:'CT Scan + Hepatology (Mahgoub)',
+    dateTime:'2025-12-29T07:30', doctor:'Dr. Amar Mahgoub',
+    location:'Liver Consultants of Texas', type:'specialist', covering:'tbd',
+    prep:'Questions for Mahgoub:\n1. Purpose of Omeprazole? How long to continue?\n2. How long to take Entecavir?\n3. Current status of liver?',
+    postNotes:'Blood work + CT scan (7:30AM). Mahgoub appt 11:30AM.\nWeight 124.7 lbs, BP 135/70\n\n5 Key Takeaways:\n1. Liver stable — ALT/AST normal, bilirubin normal, alkaline phosphatase good.\n2. Entecavir critical — continue indefinitely to prevent Hep B flare-up.\n3. Omeprazole optional — taper (every other day → stop). Can restart if needed.\n4. Watch for: abdominal fluid, yellowing of skin/eyes, constant itching, confusion/brain fog.\n5. Liver transplant: premature — need sustained cancer clearance first.\n\nNext Mahgoub appt: March 31, 2026.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-029', title:'Oncology — Chemo + Immuno Infusion',
+    dateTime:'2026-01-22T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'fanuel',
+    prep:'',
+    postNotes:'Fanuel at appt. Weight 126 lbs.\nLabs done. Chatted with Finance — initiated hardship application.\nPre-meds: Fosaprepitant, Dexamethasone, Dilaudid (pain, one-time), Magnesium.\n2 chemo + 1 immuno: Imfinzi (1hr), Gemzar (30min), Cisplatin (1hr).\n\nMorphine 15mg refill requested — pick up at 3rd floor or Wylie pharmacy.\nOlanzapine refill needed — order possibly tied to old treatment, nurse to investigate.\nEntecavir + Omeprazole refill confirmed — FedEx delivery.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-030', title:'Oncology — Chemo + Immuno Infusion',
+    dateTime:'2026-01-29T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'saron',
+    prep:'Topics:\n- Continuous fatigue/exhaustion\n- Hiccups (first few days, especially at night)\n- Swelling on legs + pelvic area — kidney/creatinine impact?\n- Pain medication dosage (morphine/oxycodone)\n- Dulcolax for constipation — how often?\n- When is next scan planned?',
+    postNotes:'Saron at appt.\nWeight 125.8 lbs, Temp 97.8, BP 110/66, Oxygen 94\n\nNew prescriptions (Walgreens Wylie):\n- Spironolactone (Aldactone): every other day for fluid retention\n- Baclofen: for hiccups, as needed up to 3×/day\n- Olanzapine: every evening for appetite + nausea\n\nPre-meds: Fosaprepitant, Methylprednisolone (replaced Dex to prevent hiccups), Magnesium.\nChemo: Gemzar (30min) + Cisplatin (slightly lower dose for kidneys).\n\nKidney update: Creatinine rose to 1.22 (baseline 0.9) — monitoring closely.\nWeight 125 lbs includes fluid retention.\n\nNext blood work: Feb 6 9AM (kidney check + steroid dosage review).',
+    updatedAt:TS
+  },
+  {
+    id:'imp-031', title:'Labs — Blood Work (Kidney + Steroid Check)',
+    dateTime:'2026-02-06T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'lab', covering:'tbd',
+    prep:'',
+    postNotes:'Scheduled to gauge kidney function and steroid dosage adjustment after Jan 29 chemo.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-032', title:'Oncology — Chemo Infusion',
+    dateTime:'2026-02-12T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'fanuel',
+    prep:'',
+    postNotes:'Fanuel at appt.\nWeight 129 lbs, BP 126/76\nPre-meds: Fosaprepitant, Palonosetron, Methylprednisolone, Magnesium Sulfate.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-033', title:'Oncology — Labs + Infusion (No Abushahin)',
+    dateTime:'2026-02-19T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Blood work + infusion only. No Abushahin appt today.\n\nPre-hydration: Magnesium Sulfate, Sodium Chloride IV.\nPre-meds: Fosaprepitant (Emend), Palonosetron (Aloxi), Methylprednisolone (Solumedrol).\nChemo: Gemcitabine (Gemzar) + Cisplatin.\n\nMorphine 15mg refill confirmed. Olanzapine 2.5mg refill — order possibly denied, nurse investigating. Entecavir + Omeprazole refill confirmed, FedEx delivery.\n\nNote: Tag Sheri Zadina on messages to Abushahin going forward.\nUpcoming: Feb 24 Terauchi 1PM telemedicine, Mar 5 labs 9:10 / Abushahin 10:00 / infusion 10:45.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-034', title:'Palliative Care — Telemedicine (Dr. Terauchi)',
+    dateTime:'2026-02-24T13:00', doctor:'Dr. Stephanie Terauchi',
+    location:'Telemedicine', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Dr. Stephanie Terauchi — 214-361-2025\n\nDaily diet recommendations:\n- Set timer every 3 hours to eat\n- 1 green tea (caffeinated) in the morning\n- 2000 calories/day + 80g protein/day to stabilize weight\n\nProtein stores: 2.6 (Jan 2026), 2.2 (Feb 19) — goal: close to 3.\n2 full Peptide cans/day goal (take 1/4 at a time).\n\nPrescriptions: Ondansetron. Follow up in ~2 weeks, start Megace.\nCommunication: Send messages through portal — goes directly to her and her nurse.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-035', title:'Oncology — Labs + Abushahin + Infusion',
+    dateTime:'2026-03-05T09:10', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Weight 117.8 lbs, BP 108/62, Protein 2.4\nLabs 9:10, Abushahin 10:00, infusion 10:45AM\n\nImodium with peptide. Scan to be scheduled.\nRefill: Lasix (drop to 20mg) and Olanzapine (5mg).\nInfusion pre-meds: Fosaprepitant, Palonosetron, Methylprednisolone, Imfinzi, Magnesium Sulfate.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-036', title:'Oncology — Chemo on Hold (Low ANC)',
+    dateTime:'2026-03-12T09:00', doctor:'Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'Chemo on hold today — ANC 0.42 (too low, high infection risk).\nKnown side effect of Cisplatin.\nNo fever, vitals stable.\nWaiting for Abushahin to confirm IV hydration or supportive fluids while at clinic.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-037', title:'Oncology — Chemo + Immuno Infusion (Dr. Dweck)',
+    dateTime:'2026-03-26T09:00', doctor:'Dr. Bradley Dweck / Dr. Laith Abushahin',
+    location:'Texas Oncology', type:'specialist', covering:'tbd',
+    prep:'Questions:\n- CT Scan (Mar 13): findings, changes vs last scan, next steps?\n- Potassium 5.1 (normal) — stop potassium chloride? At what level to restart?\n- Medication review: Spironolactone 50mg, Lasix 20mg, Potassium Chloride ER 20mEq — purpose, overlap, long-term?\n- Weight loss (118 lbs) — supplements, appetite stimulants, nutrition referral?\n- Fatigue/energy — how to improve?',
+    postNotes:'Weight 118 lbs, BP 108/67, Temp 98\nANC 2.2 (better), WBC 3.6 (better), Potassium 5.1 (normal)\nDr. Bradley Dweck (fellow) + Abushahin\n\nANC normal enough — chemo/immuno infusion done today.\nPotassium normal — likely stop potassium chloride (awaiting Abushahin confirmation).\nDad had nausea this morning — Zofran/Ondansetron as needed? Awaiting confirmation.\n\nCT Scan (Mar 13): everything worse vs Sept 2025 (radiology compared to Sept, not Dec scan — needs correction).\nAbushahin considering treatment schedule change, limited alternatives. Will print all 3 scan comparisons.\nTwo populations of cancer cells: liver + bile duct.',
+    updatedAt:TS
+  },
+  {
+    id:'imp-038', title:'Hepatology — Follow Up (Mahgoub)',
+    dateTime:'2026-03-31T09:45', doctor:'Dr. Amar Mahgoub',
+    location:'Liver Consultants of Texas', type:'specialist', covering:'tbd',
+    prep:'',
+    postNotes:'',
+    updatedAt:TS
+  }
+];
+
+window.doImport = async () => {
+  const btn    = document.getElementById('import-btn');
+  const status = document.getElementById('status');
+  btn.disabled = true;
+  status.className = 'status active';
+  status.innerHTML = '';
+
+  let done = 0, failed = 0;
+  for (const apt of APPOINTMENTS) {
+    const line = document.createElement('div');
+    line.textContent = `⏳ [${apt.id}] ${apt.title}`;
+    status.appendChild(line);
+    try {
+      await setDoc(doc(db, 'appointments', apt.id), apt);
+      done++;
+      line.textContent = `✓ [${apt.id}] ${apt.title}`;
+      line.style.color = '#3DD68C';
+    } catch(e) {
+      failed++;
+      line.textContent = `✗ [${apt.id}] ${apt.title} — ${e.message}`;
+      line.style.color = '#FF5C5C';
+    }
+    status.scrollTop = status.scrollHeight;
+  }
+
+  const summary = document.createElement('div');
+  summary.style.marginTop = '12px';
+  summary.style.fontWeight = '700';
+  if (failed === 0) {
+    summary.textContent = `✅ Done — ${done} appointments imported successfully.`;
+    summary.style.color = '#3DD68C';
+  } else {
+    summary.textContent = `⚠️ ${done} imported, ${failed} failed.`;
+    summary.style.color = '#F0A030';
+  }
+  status.appendChild(summary);
+  btn.textContent = 'Import complete';
+};
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -39,11 +39,20 @@
     <span class="topbar-date" id="today-lbl"></span>
     <span class="topbar-user" id="user-email"></span>
     <button class="btn-ghost" onclick="logout()">Sign out</button>
-    <button class="btn-add" onclick="openModal()">＋ Add medication</button>
+    <button class="btn-add" id="add-btn" onclick="handleAddBtn()">＋ Add medication</button>
   </div>
 </header>
 
 <div class="page">
+
+  <!-- PAGE TABS -->
+  <div class="page-tabs">
+    <button class="ptab active" id="tab-meds" onclick="switchTab('meds')">Medications</button>
+    <button class="ptab" id="tab-apts" onclick="switchTab('apts')">Appointments</button>
+  </div>
+
+  <!-- MEDICATIONS VIEW -->
+  <div id="view-meds">
 
   <!-- KPIs -->
   <div class="kpi-row">
@@ -106,9 +115,48 @@
       </thead>
       <tbody id="tbody"></tbody>
     </table>
-  </div>
+  </div><!-- end tbl-wrap -->
 
-</div>
+  </div><!-- end view-meds -->
+
+  <!-- APPOINTMENTS VIEW -->
+  <div id="view-apts" style="display:none">
+    <div class="apt-layout">
+
+      <!-- SIDEBAR: Mini Calendar -->
+      <div class="apt-sidebar">
+        <div class="mini-cal">
+          <div class="cal-nav">
+            <button class="cal-nav-btn" onclick="changeMonth(-1)">‹</button>
+            <div class="cal-month-label" id="cal-month-label"></div>
+            <button class="cal-nav-btn" onclick="changeMonth(1)">›</button>
+          </div>
+          <div class="cal-grid">
+            <div class="cal-dow">Su</div><div class="cal-dow">Mo</div>
+            <div class="cal-dow">Tu</div><div class="cal-dow">We</div>
+            <div class="cal-dow">Th</div><div class="cal-dow">Fr</div>
+            <div class="cal-dow">Sa</div>
+          </div>
+          <div class="cal-grid" id="cal-days"></div>
+        </div>
+      </div>
+
+      <!-- MAIN: Hero + Agenda -->
+      <div class="apt-main">
+        <div id="apt-hero"></div>
+        <div class="agenda-controls">
+          <div class="search-wrap">
+            <span class="search-ico">🔍</span>
+            <input class="search-input" id="apt-search" placeholder="Search appointments…" oninput="renderApts()">
+          </div>
+        </div>
+        <div id="apt-agenda"></div>
+      </div>
+
+    </div>
+  </div><!-- end view-apts -->
+
+</div><!-- end page -->
 
 </div><!-- end #app -->
 
@@ -162,6 +210,57 @@
 </div>
 
 <input type="file" id="file-in" accept=".json" style="display:none" onchange="handleImport(event)">
+
+<!-- APPOINTMENT MODAL -->
+<div class="modal-bg" id="apt-modal" style="display:none" onclick="aptBgClick(event)">
+  <div class="modal" onclick="event.stopPropagation()">
+    <h2 id="apt-modal-h">Add appointment</h2>
+
+    <div class="modal-section">Appointment details</div>
+    <div class="fr"><label>Title <span class="req">*</span></label><input id="apt-f-title" placeholder="e.g. Cardiology follow-up"></div>
+    <div class="f2">
+      <div class="fr"><label>Date &amp; time <span class="req">*</span></label><input id="apt-f-datetime" type="datetime-local"></div>
+      <div class="fr">
+        <label>Type</label>
+        <select id="apt-f-type">
+          <option value="">— Select —</option>
+          <option value="checkup">Checkup</option>
+          <option value="specialist">Specialist visit</option>
+          <option value="lab">Lab / blood work</option>
+          <option value="imaging">Imaging</option>
+          <option value="other">Other</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="modal-section">Provider &amp; location</div>
+    <div class="f2">
+      <div class="fr"><label>Doctor / provider</label><input id="apt-f-doctor" placeholder="Dr. Patel"></div>
+      <div class="fr"><label>Location</label><input id="apt-f-location" placeholder="MGH, Building B"></div>
+    </div>
+    <div class="fr">
+      <label>Who's covering</label>
+      <select id="apt-f-covering">
+        <option value="">— Select —</option>
+        <option value="fanuel">Fanuel</option>
+        <option value="saron">Saron</option>
+        <option value="both">Both</option>
+        <option value="tbd">TBD</option>
+      </select>
+    </div>
+
+    <div class="modal-section">Prep instructions &amp; questions</div>
+    <div class="fr"><textarea id="apt-f-prep" placeholder="e.g. Fast for 12 hours, bring insurance card, ask about A1C results…" style="min-height:100px"></textarea></div>
+
+    <div class="modal-section">Post appointment notes</div>
+    <div class="fr"><textarea id="apt-f-postnotes" placeholder="e.g. Doctor said to increase Lisinopril, follow-up in 3 months…" style="min-height:100px"></textarea></div>
+
+    <div class="mf">
+      <button class="btn-cx" onclick="closeAptModal()">Cancel</button>
+      <button class="btn-sv" onclick="saveApt()">Save appointment</button>
+    </div>
+  </div>
+</div>
 
 <script type="module" src="app.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,9 @@
   --red:#FF5C5C; --red-dim:rgba(255,92,92,.12); --red-border:rgba(255,92,92,.25);
   --amber:#F0A030; --amber-dim:rgba(240,160,48,.12); --amber-border:rgba(240,160,48,.25);
   --green:#3DD68C; --green-dim:rgba(61,214,140,.10); --green-border:rgba(61,214,140,.22);
-  --blue:#4D9EFF; --blue-dim:rgba(77,158,255,.12);
+  --blue:#4D9EFF; --blue-dim:rgba(77,158,255,.12); --blue-border:rgba(77,158,255,.25);
+  --violet:#A78BFA; --violet-dim:rgba(167,139,250,.12); --violet-border:rgba(167,139,250,.25);
+  --teal:#2DD4BF;   --teal-dim:rgba(45,212,191,.12);   --teal-border:rgba(45,212,191,.25);
   --ff:'Inter',sans-serif; --ffm:'JetBrains Mono',monospace;
 }
 html,body{height:100%}
@@ -203,12 +205,13 @@ tbody tr:hover{background:rgba(255,255,255,.022)}
 .fr{margin-bottom:11px}
 .fr label{display:block;font-size:11px;font-weight:700;color:var(--text2);text-transform:uppercase;letter-spacing:.6px;margin-bottom:4px}
 .req{color:var(--red)}
-.fr input,.fr textarea{
+.fr input,.fr textarea,.fr select{
   width:100%;font-family:var(--ff);font-size:14px;
   padding:9px 11px;border:1px solid var(--border2);border-radius:7px;
   background:var(--panel2);color:var(--text);outline:none;transition:border-color .15s;
 }
-.fr input:focus,.fr textarea:focus{border-color:rgba(255,255,255,.26)}
+.fr input:focus,.fr textarea:focus,.fr select:focus{border-color:rgba(255,255,255,.26)}
+.fr select{appearance:none}
 .fr textarea{resize:vertical;min-height:58px}
 .f2{display:grid;grid-template-columns:1fr 1fr;gap:10px}
 .fr-hint{font-size:11px;color:var(--text3);margin-top:4px}
@@ -220,6 +223,210 @@ tbody tr:hover{background:rgba(255,255,255,.022)}
 
 /* section divider for modal */
 .modal-section{font-size:10px;font-weight:700;color:var(--text3);text-transform:uppercase;letter-spacing:.8px;margin:16px 0 10px;padding-bottom:6px;border-bottom:1px solid var(--border)}
+
+/* ── PAGE TABS ── */
+.page-tabs{display:flex;gap:2px;margin-bottom:28px;border-bottom:1px solid var(--border)}
+.ptab{
+  font-family:var(--ff);font-size:13px;font-weight:600;
+  padding:10px 20px;border:none;background:transparent;
+  color:var(--text2);cursor:pointer;position:relative;transition:color .15s;
+}
+.ptab:hover{color:var(--text)}
+.ptab.active{color:var(--text)}
+.ptab.active::after{
+  content:'';position:absolute;bottom:-1px;left:0;right:0;height:2px;
+  background:var(--green);border-radius:2px 2px 0 0;
+}
+
+/* ── HERO CARD ── */
+.hero-card{
+  background:var(--panel);border:1px solid var(--border);border-radius:12px;
+  padding:20px 24px;margin-bottom:28px;
+  display:flex;align-items:center;gap:20px;
+  position:relative;overflow:hidden;
+}
+.hero-card::before{content:'';position:absolute;left:0;top:0;bottom:0;width:4px}
+.hero-card.today::before{background:var(--blue)}
+.hero-card.today .hero-card-label{color:var(--blue)}
+.hero-card.today .hero-card-time{color:var(--blue)}
+.hero-card.today .hero-date-block{background:var(--blue-dim);border-color:var(--blue-border)}
+.hero-card.today .hero-date-month,.hero-card.today .hero-date-day{color:var(--blue)}
+.hero-card.soon::before{background:var(--amber)}
+.hero-card.soon .hero-card-label{color:var(--amber)}
+.hero-card.soon .hero-card-time{color:var(--amber)}
+.hero-card.soon .hero-date-block{background:var(--amber-dim);border-color:var(--amber-border)}
+.hero-card.soon .hero-date-month,.hero-card.soon .hero-date-day{color:var(--amber)}
+.hero-card.upcoming::before{background:var(--green)}
+.hero-card.upcoming .hero-card-label{color:var(--green)}
+.hero-card.upcoming .hero-card-time{color:var(--green)}
+.hero-card.upcoming .hero-date-block{background:var(--green-dim);border-color:var(--green-border)}
+.hero-card.upcoming .hero-date-month,.hero-card.upcoming .hero-date-day{color:var(--green)}
+.hero-card-label{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.8px;margin-bottom:6px}
+.hero-card-title{font-size:20px;font-weight:700;color:var(--text);letter-spacing:-.3px;margin-bottom:6px}
+.hero-card-time{font-family:var(--ffm);font-size:16px;font-weight:600;margin-bottom:6px;letter-spacing:-.3px}
+.hero-card-meta{font-size:13px;color:var(--text2)}
+.hero-date-block{
+  display:flex;flex-direction:column;align-items:center;justify-content:center;
+  border:1px solid var(--border);border-radius:10px;padding:12px 16px;min-width:72px;text-align:center;flex-shrink:0;
+}
+.hero-date-month{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.8px;font-family:var(--ffm)}
+.hero-date-day{font-size:38px;font-weight:700;letter-spacing:-2px;line-height:1;font-family:var(--ffm)}
+.hero-body{flex:1;min-width:0}
+
+/* ── AGENDA SEARCH ── */
+.agenda-controls{margin-bottom:20px}
+.agenda-controls .search-wrap{max-width:240px}
+.agenda-controls .search-input{
+  width:100%;padding:8px 12px 8px 32px;
+}
+
+/* ── AGENDA GROUPS ── */
+.agenda-group{margin-bottom:24px}
+.group-hdr{display:flex;align-items:center;gap:10px;margin-bottom:10px}
+.group-label{font-size:10px;font-weight:700;letter-spacing:.8px;text-transform:uppercase;color:var(--text3);white-space:nowrap}
+.group-label.today-lbl{color:var(--blue)}
+.group-line{flex:1;height:1px;background:var(--border)}
+.group-count{
+  font-size:11px;font-family:var(--ffm);color:var(--text3);
+  background:var(--panel2);border:1px solid var(--border);border-radius:10px;padding:1px 8px;
+}
+
+/* ── APPOINTMENT CARD ── */
+.apt-card{
+  background:var(--panel);border:1px solid var(--border);border-radius:10px;
+  padding:14px 16px;display:flex;align-items:center;gap:14px;
+  margin-bottom:6px;transition:background .12s,border-color .12s;
+  position:relative;overflow:hidden;flex-wrap:wrap;
+}
+.apt-card:hover{background:var(--panel2);border-color:var(--border2)}
+.apt-card::before{content:'';position:absolute;left:0;top:0;bottom:0;width:3px}
+.apt-card.today::before{background:var(--blue)}
+.apt-card.soon::before{background:var(--amber)}
+.apt-card.upcoming::before{background:var(--green)}
+.apt-card.past::before{background:rgba(255,255,255,.08)}
+.apt-card-top{display:flex;align-items:center;gap:14px;width:100%;cursor:pointer}
+
+/* date block */
+.apt-date{display:flex;flex-direction:column;align-items:center;min-width:40px;flex-shrink:0;text-align:center}
+.apt-date-month{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--text3);font-family:var(--ffm)}
+.apt-date-day{font-size:22px;font-weight:700;letter-spacing:-1px;line-height:1.1;font-family:var(--ffm);color:var(--text)}
+.apt-card.today .apt-date-day{color:var(--blue)}
+.apt-card.past .apt-date-day,.apt-card.past .apt-date-month{color:var(--text3)}
+.apt-divider{width:1px;background:var(--border);align-self:stretch;flex-shrink:0;margin:2px 0}
+
+/* body */
+.apt-body{flex:1;min-width:0}
+.apt-title{font-size:14px;font-weight:600;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.apt-card.past .apt-title{color:var(--text2)}
+.apt-time{font-family:var(--ffm);font-size:13px;font-weight:600;color:var(--text);margin-top:3px}
+.apt-card.past .apt-time{color:var(--text3)}
+.apt-card.today .apt-time{color:var(--blue)}
+.apt-card.soon .apt-time{color:var(--amber)}
+.apt-card.upcoming .apt-time{color:var(--green)}
+.apt-meta{display:flex;align-items:center;gap:8px;margin-top:4px;flex-wrap:wrap}
+.apt-doctor,.apt-location{font-size:12px;color:var(--text2)}
+.apt-card.past .apt-doctor,.apt-card.past .apt-location{color:var(--text3)}
+.apt-sep{color:var(--border2);font-size:11px}
+.type-chip{
+  font-size:10px;font-weight:600;letter-spacing:.3px;
+  background:var(--panel2);border:1px solid var(--border);
+  border-radius:4px;padding:2px 6px;font-family:var(--ffm);color:var(--text3);white-space:nowrap;
+}
+
+/* covering pill */
+.covering-pill{
+  display:inline-flex;align-items:center;gap:5px;
+  font-size:11px;font-weight:600;padding:3px 9px;border-radius:20px;
+  border:1px solid var(--border2);background:var(--panel2);
+  color:var(--text2);white-space:nowrap;font-family:var(--ffm);flex-shrink:0;
+}
+.covering-pill::before{content:'';width:6px;height:6px;border-radius:50%;background:var(--text3);flex-shrink:0}
+.covering-pill.fanuel{color:var(--violet);border-color:var(--violet-border);background:var(--violet-dim)}
+.covering-pill.fanuel::before{background:var(--violet)}
+.covering-pill.saron{color:var(--teal);border-color:var(--teal-border);background:var(--teal-dim)}
+.covering-pill.saron::before{background:var(--teal)}
+.covering-pill.both::before{background:linear-gradient(90deg,var(--violet) 50%,var(--teal) 50%)}
+
+/* expand/collapse */
+.apt-expand{
+  display:none;width:100%;margin-top:12px;
+  padding-top:12px;border-top:1px solid var(--border);
+}
+.apt-expand.open{display:block}
+.apt-expand-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.expand-section-label{
+  font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.7px;
+  color:var(--text3);margin-bottom:6px;
+}
+.expand-text{font-size:13px;color:var(--text2);line-height:1.6;white-space:pre-wrap}
+.expand-empty{font-size:12px;color:var(--text3);font-style:italic}
+.apt-chevron{font-size:11px;color:var(--text3);margin-left:auto;flex-shrink:0;transition:transform .2s}
+.apt-chevron.open{transform:rotate(180deg)}
+
+/* icon-only action buttons */
+.apt-actions{display:flex;gap:4px;flex-shrink:0;align-items:center}
+.act-icon{
+  width:30px;height:30px;display:flex;align-items:center;justify-content:center;
+  border-radius:6px;border:1px solid transparent;background:transparent;
+  cursor:pointer;transition:all .12s;color:var(--text3);font-size:14px;
+}
+.act-icon:hover{background:var(--panel2);border-color:var(--border2);color:var(--text)}
+.act-icon.del:hover{background:var(--red-dim);border-color:var(--red-border);color:var(--red)}
+
+/* past group toggle */
+.past-toggle{
+  display:flex;align-items:center;gap:8px;cursor:pointer;
+  font-size:12px;color:var(--text3);padding:8px 0;
+  border:none;background:transparent;font-family:var(--ff);transition:color .12s;
+}
+.past-toggle:hover{color:var(--text2)}
+.past-toggle-icon{font-size:11px;transition:transform .2s}
+.past-toggle-icon.open{transform:rotate(180deg)}
+.past-content{display:none}
+.past-content.open{display:block}
+.past-group-wrap{opacity:.55;transition:opacity .15s}
+.past-group-wrap:hover{opacity:.8}
+
+/* ── TWO-COLUMN LAYOUT ── */
+.apt-layout{display:flex;gap:20px;align-items:flex-start}
+.apt-sidebar{width:272px;flex-shrink:0;position:sticky;top:70px}
+.apt-main{flex:1;min-width:0}
+
+/* ── MINI CALENDAR ── */
+.mini-cal{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:16px 20px}
+.cal-nav{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px}
+.cal-month-label{font-size:13px;font-weight:700;color:var(--text);letter-spacing:-.2px}
+.cal-nav-btn{
+  width:28px;height:28px;display:flex;align-items:center;justify-content:center;
+  border:1px solid var(--border2);border-radius:6px;background:transparent;
+  color:var(--text2);cursor:pointer;font-size:13px;transition:all .12s;
+}
+.cal-nav-btn:hover{background:var(--panel2);color:var(--text)}
+.cal-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:2px}
+.cal-dow{
+  text-align:center;font-size:10px;font-weight:700;color:var(--text3);
+  text-transform:uppercase;letter-spacing:.5px;padding-bottom:8px;font-family:var(--ffm);
+}
+.cal-day{
+  position:relative;display:flex;flex-direction:column;align-items:center;
+  justify-content:center;padding:6px 2px;border-radius:7px;cursor:pointer;
+  transition:background .1s;min-height:36px;
+}
+.cal-day:hover{background:var(--panel2)}
+.cal-day.empty{cursor:default;pointer-events:none}
+.cal-day-num{font-size:12px;font-family:var(--ffm);color:var(--text2);line-height:1}
+.cal-day.today .cal-day-num{
+  background:var(--blue);color:#fff;
+  width:22px;height:22px;border-radius:50%;
+  display:flex;align-items:center;justify-content:center;font-weight:700;
+}
+.cal-day.has-apt .cal-day-num{color:var(--text)}
+.cal-day.faded .cal-day-num{color:var(--text3)}
+.cal-dots{display:flex;gap:3px;margin-top:3px;justify-content:center;min-height:5px}
+.cal-dot{width:5px;height:5px;border-radius:50%;flex-shrink:0}
+.cal-dot.fanuel{background:var(--violet)}
+.cal-dot.saron{background:var(--teal)}
+.cal-dot.tbd{background:var(--text3)}
 
 @media(max-width:700px){
   /* ── layout ── */
@@ -237,6 +444,18 @@ tbody tr:hover{background:rgba(255,255,255,.022)}
   /* ── search ── */
   .search-input{width:120px}
   .search-input:focus{width:150px}
+
+  /* ── appointments ── */
+  .ptab{font-size:12px;padding:8px 14px}
+  .hero-card{flex-direction:column;align-items:flex-start;gap:12px}
+  .hero-date-block{flex-direction:row;align-items:baseline;gap:8px;padding:8px 14px}
+  .hero-date-day{font-size:28px}
+  .hero-card-title{font-size:17px}
+  .apt-layout{flex-direction:column}
+  .apt-sidebar{width:100%;position:static}
+  .mini-cal{margin-bottom:20px}
+  .apt-expand-grid{grid-template-columns:1fr}
+  .agenda-controls .search-wrap{max-width:100%}
 
   /* ── card layout: convert table rows into cards ── */
   .tbl-wrap{border:none;background:transparent}


### PR DESCRIPTION
…mport

- Tab bar (Medications | Appointments) with dynamic + Add button
- Two-column desktop layout: sticky mini calendar sidebar + hero card + agenda
- Agenda groups: Today (blue), This week (amber), Upcoming (green), Past (collapsed)
- Expandable appointment cards with prep/questions and post-appointment notes
- Covering pill per appointment (Fanuel=violet, Saron=teal, Both, TBD)
- Mini calendar with assignee-colored dots; clicking a day scrolls to that appointment
- Full CRUD via Firestore (appointments collection)
- bulk-import-apts.html for one-time data seeding