### PR TITLE
Add export-to-calendar feature for appointments

### DIFF
--- a/client/src/components/apts/AptDetailModal.jsx
+++ b/client/src/components/apts/AptDetailModal.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { fmtAptDateBlock, fmtAptTime, coveringLabel } from '../../lib/aptUtils'
+import { fmtAptDateBlock, fmtAptTime, coveringLabel, exportToICS } from '../../lib/aptUtils'
 import { saveApt, delApt } from '../../lib/firestore'
 import { useSpecialties, specialtyLabel } from '../../hooks/useSpecialties'
 
@@ -220,6 +220,9 @@ export default function AptDetailModal({ apt, note, careTeam = [], onClose }) {
                 {saveStatus === 'error'  && 'Error'}
               </span>
             )}
+            <button className="btn-export-ics" onClick={() => exportToICS(apt)} aria-label="Export to calendar" title="Export to calendar (.ics)">
+              📅
+            </button>
             <button className="btn-delete-detail" onClick={async () => {
               if (!confirm(`Remove "${apt.title}"?`)) return
               try { await delApt(apt.id); onClose() } catch { alert('Failed to delete. Check your connection.') }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -386,6 +386,8 @@ tbody tr:hover{background:rgba(255,255,255,.022)}
 .btn-edit-detail:hover{background:rgba(91,138,240,.1)}
 .btn-delete-detail{font-size:14px;background:transparent;border:none;cursor:pointer;padding:4px 6px;border-radius:6px;opacity:.5}
 .btn-delete-detail:hover{opacity:1;background:rgba(216,90,48,.1)}
+.btn-export-ics{font-size:14px;background:transparent;border:none;cursor:pointer;padding:4px 6px;border-radius:6px;opacity:.5}
+.btn-export-ics:hover{opacity:1;background:rgba(91,138,240,.1)}
 .apt-note-indicator{font-size:13px;margin-left:auto;flex-shrink:0;width:24px;text-align:center;opacity:.45}
 .apt-note-indicator.has-note{opacity:1}
 .apt-note-indicator.no-note{font-size:11px;color:var(--text3)}

--- a/client/src/lib/aptUtils.js
+++ b/client/src/lib/aptUtils.js
@@ -39,3 +39,44 @@ export function coveringLabel(c) {
   return { fanuel: 'Fanuel', saron: 'Saron', both: 'Both', tbd: 'TBD' }[c] || 'TBD'
 }
 
+export function exportToICS(apt) {
+  const start = new Date(apt.dateTime)
+  const end = new Date(start.getTime() + 60 * 60 * 1000)
+  const toICSDate = d => d.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z'
+  const icsEsc = s => String(s).replace(/\\/g, '\\\\').replace(/;/g, '\\;').replace(/,/g, '\\,').replace(/\n/g, '\\n')
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Dad Med Tracker//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${apt.id}@dad-med-tracker`,
+    `DTSTAMP:${toICSDate(new Date())}`,
+    `DTSTART:${toICSDate(start)}`,
+    `DTEND:${toICSDate(end)}`,
+    `SUMMARY:${icsEsc(apt.title || 'Appointment')}`,
+  ]
+
+  if (apt.location) lines.push(`LOCATION:${icsEsc(apt.location)}`)
+
+  const descParts = []
+  if (apt.doctor) descParts.push(`Doctor: ${apt.doctor}`)
+  if (apt.prep) descParts.push(`Prep: ${apt.prep}`)
+  if (apt.postNotes) descParts.push(`Notes: ${apt.postNotes}`)
+  if (descParts.length) lines.push(`DESCRIPTION:${icsEsc(descParts.join('\n'))}`)
+
+  lines.push('END:VEVENT', 'END:VCALENDAR')
+
+  const blob = new Blob([lines.join('\r\n')], { type: 'text/calendar;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${(apt.title || 'appointment').replace(/\s+/g, '-').toLowerCase()}.ics`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+


### PR DESCRIPTION
Generates and downloads a standard .ics file from the appointment detail
modal, populated with title, time, location, doctor, prep notes, and
post-visit notes for import into any calendar app.

https://claude.ai/code/session_01FSH3cKrcvYEgGg2bbePjPg