### PR TITLE
Fix CareTeamPanel elements flush against screen edges

### DIFF
--- a/client/src/components/CareTeamPanel.jsx
+++ b/client/src/components/CareTeamPanel.jsx
@@ -86,7 +86,7 @@ export default function CareTeamPanel({ careTeam }) {
   const avatarSrc = photoPreview || form.imageUrl
 
   return (
-    <div className="view-wrap">
+    <div className="page">
       <div className="care-team-panel">
         {view === 'list' ? (
           <>


### PR DESCRIPTION
Replace view-wrap (no CSS) with page class (padding: 20px 24px 48px)
to match every other view and give the form proper horizontal/vertical breathing room.

https://claude.ai/code/session_01D3ajcZyoEV4jcVe3dJrjUV