### PR TITLE
Fix cursor reset and auto-caps when typing in edit modals

### DIFF
--- a/client/src/components/apts/AptDetailModal.jsx
+++ b/client/src/components/apts/AptDetailModal.jsx
@@ -7,6 +7,125 @@ function PhaseChip({ label }) {
   return <span className="apt-detail-chip">{label}</span>
 }
 
+function InlineField({ field, value, type = 'text', placeholder = '', editCtx }) {
+  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
+  if (editingField === field) {
+    return (
+      <input
+        className="inline-input"
+        type={type}
+        value={draftValue}
+        autoFocus
+        onChange={e => setDraftValue(e.target.value)}
+        onBlur={() => commitEdit(field, draftValue)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') commitEdit(field, draftValue)
+          if (e.key === 'Escape') cancelEdit()
+        }}
+        placeholder={placeholder}
+      />
+    )
+  }
+  return (
+    <span
+      className="inline-val"
+      tabIndex={0}
+      onClick={() => startEdit(field, value)}
+      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
+    >
+      {value || ''}
+    </span>
+  )
+}
+
+function InlineTextarea({ field, value, placeholder = '', editCtx }) {
+  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
+  if (editingField === field) {
+    return (
+      <textarea
+        className="inline-input"
+        rows={4}
+        value={draftValue}
+        autoFocus
+        onChange={e => setDraftValue(e.target.value)}
+        onBlur={() => commitEdit(field, draftValue)}
+        onKeyDown={e => e.key === 'Escape' && cancelEdit()}
+        placeholder={placeholder}
+      />
+    )
+  }
+  return (
+    <span
+      className="inline-val"
+      style={{ whiteSpace: 'pre-wrap', display: 'block' }}
+      tabIndex={0}
+      onClick={() => startEdit(field, value)}
+      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
+    >
+      {value || <span style={{ color: 'var(--text3)' }}>Not documented</span>}
+    </span>
+  )
+}
+
+function InlineDoctorSelect({ field, value, careTeam, specialties, editCtx }) {
+  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
+  if (editingField === field) {
+    return (
+      <select
+        className="inline-input"
+        value={draftValue}
+        autoFocus
+        onChange={e => setDraftValue(e.target.value)}
+        onBlur={() => commitEdit(field, draftValue)}
+        onKeyDown={e => e.key === 'Escape' && cancelEdit()}
+      >
+        <option value="">Select doctor…</option>
+        {careTeam.map(dr => (
+          <option key={dr.id} value={dr.name}>
+            {dr.name}{dr.specialty ? ` · ${specialtyLabel(specialties, dr.specialty)}` : ''}
+          </option>
+        ))}
+      </select>
+    )
+  }
+  return (
+    <span
+      className="apt-detail-chip"
+      style={{ cursor: 'pointer' }}
+      tabIndex={0}
+      onClick={() => startEdit(field, value)}
+      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
+      title="Click to edit"
+    >
+      {value || <span style={{ color: 'var(--text3)' }}>No doctor</span>}
+    </span>
+  )
+}
+
+function CoveringPills({ covering, commitEdit }) {
+  const options = [{ v: 'fanuel', l: 'Fanuel' }, { v: 'saron', l: 'Saron' }]
+  return (
+    <>
+      {options.map(({ v, l }) => {
+        const selected = covering === v
+        return (
+          <span
+            key={v}
+            className={`covering-pill${selected ? ` ${v}` : ''}`}
+            style={{ cursor: 'pointer', opacity: selected ? 1 : 0.4 }}
+            tabIndex={0}
+            onClick={() => commitEdit('covering', covering === v ? '' : v)}
+            onKeyDown={e => e.key === 'Enter' && commitEdit('covering', covering === v ? '' : v)}
+            title={selected ? `Remove ${l}` : `Set ${l}`}
+          >
+            {l}
+          </span>
+        )
+      })}
+    </>
+  )
+}
+
 export default function AptDetailModal({ apt, note, careTeam = [], onClose }) {
   const specialties = useSpecialties()
   const [fullOpen, setFullOpen] = useState(false)
@@ -74,122 +193,7 @@ export default function AptDetailModal({ apt, note, careTeam = [], onClose }) {
     }, 600)
   }
 
-  function InlineField({ field, value, type = 'text', placeholder = '' }) {
-    if (editingField === field) {
-      return (
-        <input
-          className="inline-input"
-          type={type}
-          value={draftValue}
-          autoFocus
-          onChange={e => setDraftValue(e.target.value)}
-          onBlur={() => commitEdit(field, draftValue)}
-          onKeyDown={e => {
-            if (e.key === 'Enter') commitEdit(field, draftValue)
-            if (e.key === 'Escape') cancelEdit()
-          }}
-          placeholder={placeholder}
-        />
-      )
-    }
-    return (
-      <span
-        className="inline-val"
-        tabIndex={0}
-        onClick={() => startEdit(field, value)}
-        onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
-      >
-        {value || ''}
-      </span>
-    )
-  }
-
-  function InlineTextarea({ field, value, placeholder = '' }) {
-    if (editingField === field) {
-      return (
-        <textarea
-          className="inline-input"
-          rows={4}
-          value={draftValue}
-          autoFocus
-          onChange={e => setDraftValue(e.target.value)}
-          onBlur={() => commitEdit(field, draftValue)}
-          onKeyDown={e => e.key === 'Escape' && cancelEdit()}
-          placeholder={placeholder}
-        />
-      )
-    }
-    return (
-      <span
-        className="inline-val"
-        style={{ whiteSpace: 'pre-wrap', display: 'block' }}
-        tabIndex={0}
-        onClick={() => startEdit(field, value)}
-        onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
-      >
-        {value || <span style={{ color: 'var(--text3)' }}>Not documented</span>}
-      </span>
-    )
-  }
-
-  function InlineDoctorSelect({ field, value }) {
-    if (editingField === field) {
-      return (
-        <select
-          className="inline-input"
-          value={draftValue}
-          autoFocus
-          onChange={e => setDraftValue(e.target.value)}
-          onBlur={() => commitEdit(field, draftValue)}
-          onKeyDown={e => e.key === 'Escape' && cancelEdit()}
-        >
-          <option value="">Select doctor…</option>
-          {careTeam.map(dr => (
-            <option key={dr.id} value={dr.name}>
-              {dr.name}{dr.specialty ? ` · ${specialtyLabel(specialties, dr.specialty)}` : ''}
-            </option>
-          ))}
-        </select>
-      )
-    }
-    return (
-      <span
-        className="apt-detail-chip"
-        style={{ cursor: 'pointer' }}
-        tabIndex={0}
-        onClick={() => startEdit(field, value)}
-        onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
-        title="Click to edit"
-      >
-        {value || <span style={{ color: 'var(--text3)' }}>No doctor</span>}
-      </span>
-    )
-  }
-
-  function CoveringPills() {
-    const options = [{ v: 'fanuel', l: 'Fanuel' }, { v: 'saron', l: 'Saron' }]
-    const current = (pendingData.current ?? apt).covering
-    return (
-      <>
-        {options.map(({ v, l }) => {
-          const selected = current === v
-          return (
-            <span
-              key={v}
-              className={`covering-pill${selected ? ` ${v}` : ''}`}
-              style={{ cursor: 'pointer', opacity: selected ? 1 : 0.4 }}
-              tabIndex={0}
-              onClick={() => commitEdit('covering', current === v ? '' : v)}
-              onKeyDown={e => e.key === 'Enter' && commitEdit('covering', current === v ? '' : v)}
-              title={selected ? `Remove ${l}` : `Set ${l}`}
-            >
-              {l}
-            </span>
-          )
-        })}
-      </>
-    )
-  }
+  const editCtx = { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit }
 
   return (
     <div className="modal-bg" onClick={e => { if (e.target === e.currentTarget) onClose() }}>
@@ -204,10 +208,10 @@ export default function AptDetailModal({ apt, note, careTeam = [], onClose }) {
             </div>
             <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ fontSize: 16, fontWeight: 700, color: 'var(--text)' }}>
-                <InlineField field="title" value={apt.title} placeholder="Appointment title" />
+                <InlineField field="title" value={apt.title} placeholder="Appointment title" editCtx={editCtx} />
               </div>
               <div className="note-meta">
-                <InlineField field="dateTime" value={apt.dateTime} type="datetime-local" />
+                <InlineField field="dateTime" value={apt.dateTime} type="datetime-local" editCtx={editCtx} />
               </div>
             </div>
           </div>
@@ -233,7 +237,7 @@ export default function AptDetailModal({ apt, note, careTeam = [], onClose }) {
 
         {/* Appointment meta — inline editable */}
         <div className="apt-detail-meta">
-          <InlineDoctorSelect field="doctor" value={apt.doctor} />
+          <InlineDoctorSelect field="doctor" value={apt.doctor} careTeam={careTeam} specialties={specialties} editCtx={editCtx} />
           {editingField === 'location'
             ? <input
                 className="inline-input"
@@ -259,17 +263,17 @@ export default function AptDetailModal({ apt, note, careTeam = [], onClose }) {
                 {apt.location || <span style={{ color: 'var(--text3)' }}>Add location</span>}
               </span>
           }
-          <CoveringPills />
+          <CoveringPills covering={(pendingData.current ?? apt).covering} commitEdit={commitEdit} />
         </div>
 
         {/* Prep & Post — inline editable */}
         <div className="note-key-section">
           <div className="note-key-label">Prep &amp; Questions</div>
-          <InlineTextarea field="prep" value={apt.prep} placeholder="Pre-visit instructions, questions to ask…" />
+          <InlineTextarea field="prep" value={apt.prep} placeholder="Pre-visit instructions, questions to ask…" editCtx={editCtx} />
         </div>
         <div className="note-key-section">
           <div className="note-key-label">Appointment Notes</div>
-          <InlineTextarea field="postNotes" value={apt.postNotes} placeholder="Follow-up notes from the visit…" />
+          <InlineTextarea field="postNotes" value={apt.postNotes} placeholder="Follow-up notes from the visit…" editCtx={editCtx} />
         </div>
 
         {/* Clinical note sections — read-only */}

--- a/client/src/components/meds/MedRow.jsx
+++ b/client/src/components/meds/MedRow.jsx
@@ -10,6 +10,101 @@ const PRESETS = [
   { value: 'custom',          label: 'Custom…' },
 ]
 
+function InlineField({ field, value, type = 'text', placeholder = '', editCtx }) {
+  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
+  if (editingField === field) {
+    return (
+      <input
+        className="inline-input"
+        type={type}
+        value={draftValue}
+        autoFocus
+        onChange={e => setDraftValue(e.target.value)}
+        onBlur={() => commitEdit(field, draftValue)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') commitEdit(field, draftValue)
+          if (e.key === 'Escape') cancelEdit()
+        }}
+        placeholder={placeholder}
+        onClick={e => e.stopPropagation()}
+      />
+    )
+  }
+  return (
+    <span
+      className="inline-val"
+      tabIndex={0}
+      onClick={e => { e.stopPropagation(); startEdit(field, value) }}
+      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
+    >
+      {value || <span style={{ color: 'var(--text3)' }}>—</span>}
+    </span>
+  )
+}
+
+function InlineTextarea({ field, value, placeholder = '', editCtx }) {
+  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
+  if (editingField === field) {
+    return (
+      <textarea
+        className="inline-input"
+        rows={3}
+        value={draftValue}
+        autoFocus
+        onChange={e => setDraftValue(e.target.value)}
+        onBlur={() => commitEdit(field, draftValue)}
+        onKeyDown={e => e.key === 'Escape' && cancelEdit()}
+        placeholder={placeholder}
+        onClick={e => e.stopPropagation()}
+      />
+    )
+  }
+  return (
+    <span
+      className="inline-val"
+      style={{ whiteSpace: 'pre-wrap', display: 'block' }}
+      tabIndex={0}
+      onClick={e => { e.stopPropagation(); startEdit(field, value) }}
+      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
+    >
+      {value || <span style={{ color: 'var(--text3)' }}>—</span>}
+    </span>
+  )
+}
+
+function InlineSelect({ field, value, options, placeholder = '', editCtx }) {
+  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
+  if (editingField === field) {
+    return (
+      <select
+        className="inline-input"
+        value={draftValue}
+        autoFocus
+        onChange={e => setDraftValue(e.target.value)}
+        onBlur={() => commitEdit(field, draftValue)}
+        onKeyDown={e => e.key === 'Escape' && cancelEdit()}
+        onClick={e => e.stopPropagation()}
+      >
+        {placeholder && <option value="">{placeholder}</option>}
+        {options.map(o => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+    )
+  }
+  const found = options.find(o => o.value === value)
+  return (
+    <span
+      className="inline-val"
+      tabIndex={0}
+      onClick={e => { e.stopPropagation(); startEdit(field, value) }}
+      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
+    >
+      {found ? found.label : (value || <span style={{ color: 'var(--text3)' }}>—</span>)}
+    </span>
+  )
+}
+
 export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand }) {
   const [menuOpen, setMenuOpen] = useState(false)
   const [confirming, setConfirming] = useState(false)
@@ -94,97 +189,7 @@ export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand })
     }, 600)
   }
 
-  function InlineField({ field, value, type = 'text', placeholder = '' }) {
-    if (editingField === field) {
-      return (
-        <input
-          className="inline-input"
-          type={type}
-          value={draftValue}
-          autoFocus
-          onChange={e => setDraftValue(e.target.value)}
-          onBlur={() => commitEdit(field, draftValue)}
-          onKeyDown={e => {
-            if (e.key === 'Enter') commitEdit(field, draftValue)
-            if (e.key === 'Escape') cancelEdit()
-          }}
-          placeholder={placeholder}
-          onClick={e => e.stopPropagation()}
-        />
-      )
-    }
-    return (
-      <span
-        className="inline-val"
-        tabIndex={0}
-        onClick={e => { e.stopPropagation(); startEdit(field, value) }}
-        onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
-      >
-        {value || <span style={{ color: 'var(--text3)' }}>—</span>}
-      </span>
-    )
-  }
-
-  function InlineTextarea({ field, value, placeholder = '' }) {
-    if (editingField === field) {
-      return (
-        <textarea
-          className="inline-input"
-          rows={3}
-          value={draftValue}
-          autoFocus
-          onChange={e => setDraftValue(e.target.value)}
-          onBlur={() => commitEdit(field, draftValue)}
-          onKeyDown={e => e.key === 'Escape' && cancelEdit()}
-          placeholder={placeholder}
-          onClick={e => e.stopPropagation()}
-        />
-      )
-    }
-    return (
-      <span
-        className="inline-val"
-        style={{ whiteSpace: 'pre-wrap', display: 'block' }}
-        tabIndex={0}
-        onClick={e => { e.stopPropagation(); startEdit(field, value) }}
-        onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
-      >
-        {value || <span style={{ color: 'var(--text3)' }}>—</span>}
-      </span>
-    )
-  }
-
-  function InlineSelect({ field, value, options, placeholder = '' }) {
-    if (editingField === field) {
-      return (
-        <select
-          className="inline-input"
-          value={draftValue}
-          autoFocus
-          onChange={e => setDraftValue(e.target.value)}
-          onBlur={() => commitEdit(field, draftValue)}
-          onKeyDown={e => e.key === 'Escape' && cancelEdit()}
-          onClick={e => e.stopPropagation()}
-        >
-          {placeholder && <option value="">{placeholder}</option>}
-          {options.map(o => (
-            <option key={o.value} value={o.value}>{o.label}</option>
-          ))}
-        </select>
-      )
-    }
-    const found = options.find(o => o.value === value)
-    return (
-      <span
-        className="inline-val"
-        tabIndex={0}
-        onClick={e => { e.stopPropagation(); startEdit(field, value) }}
-        onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
-      >
-        {found ? found.label : (value || <span style={{ color: 'var(--text3)' }}>—</span>)}
-      </span>
-    )
-  }
+  const editCtx = { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit }
 
   const doctorOptions = [
     { value: '', label: 'No doctor' },
@@ -315,13 +320,13 @@ export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand })
             {/* Name — full width */}
             <div className="med-drawer-item" style={{ gridColumn: '1 / -1' }}>
               <span className="med-drawer-lbl">Name</span>
-              <InlineField field="name" value={m.name} placeholder="e.g. Metformin" />
+              <InlineField field="name" value={m.name} placeholder="e.g. Metformin" editCtx={editCtx} />
             </div>
 
             {/* Dose + Frequency */}
             <div className="med-drawer-item">
               <span className="med-drawer-lbl">Dose / strength</span>
-              <InlineField field="dose" value={m.dose} placeholder="e.g. 500 mg" />
+              <InlineField field="dose" value={m.dose} placeholder="e.g. 500 mg" editCtx={editCtx} />
             </div>
             <div className="med-drawer-item">
               <span className="med-drawer-lbl">Frequency</span>
@@ -329,6 +334,7 @@ export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand })
                 field="frequencyPreset"
                 value={m.frequencyPreset || 'once-daily'}
                 options={PRESETS}
+                editCtx={editCtx}
               />
             </div>
 
@@ -336,48 +342,48 @@ export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand })
             {(pendingData.current ?? m).frequencyPreset === 'custom' && <>
               <div className="med-drawer-item">
                 <span className="med-drawer-lbl">Pills / dose</span>
-                <InlineField field="frequencyCustomCount" value={m.frequencyCustomCount} type="number" placeholder="1" />
+                <InlineField field="frequencyCustomCount" value={m.frequencyCustomCount} type="number" placeholder="1" editCtx={editCtx} />
               </div>
               <div className="med-drawer-item">
                 <span className="med-drawer-lbl">Every (days)</span>
-                <InlineField field="frequencyCustomEvery" value={m.frequencyCustomEvery} type="number" placeholder="1" />
+                <InlineField field="frequencyCustomEvery" value={m.frequencyCustomEvery} type="number" placeholder="1" editCtx={editCtx} />
               </div>
             </>}
 
             {/* Last filled + Supply */}
             <div className="med-drawer-item">
               <span className="med-drawer-lbl">Last filled</span>
-              <InlineField field="filledDate" value={m.filledDate} type="date" />
+              <InlineField field="filledDate" value={m.filledDate} type="date" editCtx={editCtx} />
             </div>
             <div className="med-drawer-item">
               <span className="med-drawer-lbl">Pills in bottle</span>
-              <InlineField field="supply" value={m.supply} type="number" placeholder="e.g. 30" />
+              <InlineField field="supply" value={m.supply} type="number" placeholder="e.g. 30" editCtx={editCtx} />
             </div>
 
             {/* Refill date + Pharmacy */}
             <div className="med-drawer-item">
               <span className="med-drawer-lbl">Next refill</span>
-              <InlineField field="refillDate" value={m.refillDate} type="date" />
+              <InlineField field="refillDate" value={m.refillDate} type="date" editCtx={editCtx} />
             </div>
             <div className="med-drawer-item">
               <span className="med-drawer-lbl">Pharmacy</span>
-              <InlineField field="pharmacy" value={m.pharmacy} placeholder="e.g. Walgreens" />
+              <InlineField field="pharmacy" value={m.pharmacy} placeholder="e.g. Walgreens" editCtx={editCtx} />
             </div>
 
             {/* Rx # + Doctor */}
             <div className="med-drawer-item">
               <span className="med-drawer-lbl">Rx #</span>
-              <InlineField field="rxNum" value={m.rxNum} placeholder="optional" />
+              <InlineField field="rxNum" value={m.rxNum} placeholder="optional" editCtx={editCtx} />
             </div>
             <div className="med-drawer-item">
               <span className="med-drawer-lbl">Doctor</span>
-              <InlineSelect field="doctor" value={m.doctor} options={doctorOptions} />
+              <InlineSelect field="doctor" value={m.doctor} options={doctorOptions} editCtx={editCtx} />
             </div>
 
             {/* Instructions — full width */}
             <div className="med-drawer-item" style={{ gridColumn: '1 / -1' }}>
               <span className="med-drawer-lbl">Instructions</span>
-              <InlineTextarea field="instructions" value={m.instructions} placeholder="e.g. Take with food" />
+              <InlineTextarea field="instructions" value={m.instructions} placeholder="e.g. Take with food" editCtx={editCtx} />
             </div>
 
           </div>

--- a/client/src/components/tasks/TaskModal.jsx
+++ b/client/src/components/tasks/TaskModal.jsx
@@ -10,6 +10,66 @@ const EMPTY = {
   dueDate: '', status: 'todo', priority: 'medium'
 }
 
+function InlineField({ field, value, type = 'text', placeholder = '', editCtx }) {
+  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
+  if (editingField === field) {
+    return (
+      <input
+        className="inline-input"
+        type={type}
+        value={draftValue}
+        autoFocus
+        onChange={e => setDraftValue(e.target.value)}
+        onBlur={() => commitEdit(field, draftValue)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') commitEdit(field, draftValue)
+          if (e.key === 'Escape') cancelEdit()
+        }}
+        placeholder={placeholder}
+      />
+    )
+  }
+  return (
+    <span
+      className="inline-val"
+      tabIndex={0}
+      onClick={() => startEdit(field, value)}
+      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
+    >
+      {value || <span style={{ color: 'var(--text3)' }}>{placeholder || '—'}</span>}
+    </span>
+  )
+}
+
+function InlineTextarea({ field, value, placeholder = '', editCtx }) {
+  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
+  if (editingField === field) {
+    return (
+      <textarea
+        className="inline-input"
+        rows={4}
+        value={draftValue}
+        autoFocus
+        onChange={e => setDraftValue(e.target.value)}
+        onBlur={() => commitEdit(field, draftValue)}
+        onKeyDown={e => e.key === 'Escape' && cancelEdit()}
+        placeholder={placeholder}
+      />
+    )
+  }
+  return (
+    <span
+      className="inline-val"
+      style={{ whiteSpace: 'pre-wrap', display: 'block' }}
+      tabIndex={0}
+      onClick={() => startEdit(field, value)}
+      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
+    >
+      {value || <span style={{ color: 'var(--text3)' }}>Not documented</span>}
+    </span>
+  )
+}
+
 export default function TaskModal({ tasks, careTeam, users, editId, onClose, user }) {
   const isMobile = useIsMobile()
   const [form, setForm] = useState(EMPTY)
@@ -217,63 +277,7 @@ export default function TaskModal({ tasks, careTeam, users, editId, onClose, use
     }, 600)
   }
 
-  function InlineField({ field, value, type = 'text', placeholder = '' }) {
-    if (editingField === field) {
-      return (
-        <input
-          className="inline-input"
-          type={type}
-          value={draftValue}
-          autoFocus
-          onChange={e => setDraftValue(e.target.value)}
-          onBlur={() => commitEdit(field, draftValue)}
-          onKeyDown={e => {
-            if (e.key === 'Enter') commitEdit(field, draftValue)
-            if (e.key === 'Escape') cancelEdit()
-          }}
-          placeholder={placeholder}
-        />
-      )
-    }
-    return (
-      <span
-        className="inline-val"
-        tabIndex={0}
-        onClick={() => startEdit(field, value)}
-        onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
-      >
-        {value || <span style={{ color: 'var(--text3)' }}>{placeholder || '—'}</span>}
-      </span>
-    )
-  }
-
-  function InlineTextarea({ field, value, placeholder = '' }) {
-    if (editingField === field) {
-      return (
-        <textarea
-          className="inline-input"
-          rows={4}
-          value={draftValue}
-          autoFocus
-          onChange={e => setDraftValue(e.target.value)}
-          onBlur={() => commitEdit(field, draftValue)}
-          onKeyDown={e => e.key === 'Escape' && cancelEdit()}
-          placeholder={placeholder}
-        />
-      )
-    }
-    return (
-      <span
-        className="inline-val"
-        style={{ whiteSpace: 'pre-wrap', display: 'block' }}
-        tabIndex={0}
-        onClick={() => startEdit(field, value)}
-        onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
-      >
-        {value || <span style={{ color: 'var(--text3)' }}>Not documented</span>}
-      </span>
-    )
-  }
+  const editCtx = { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit }
 
   const priorityColor = { low: 'var(--text2)', medium: '#BA7517', high: '#D85A30' }
 
@@ -398,10 +402,10 @@ export default function TaskModal({ tasks, careTeam, users, editId, onClose, use
           <div className="modal-task-header">
             <div style={{ flex: 1, minWidth: 0 }}>
               <div style={{ fontSize: 16, fontWeight: 700, color: 'var(--text)', marginBottom: 4 }}>
-                <InlineField field="title" value={form.title} placeholder="Task title" />
+                <InlineField field="title" value={form.title} placeholder="Task title" editCtx={editCtx} />
               </div>
               <div style={{ fontSize: 12, color: 'var(--text2)' }}>
-                <InlineField field="dueDate" value={form.dueDate} type="date" />
+                <InlineField field="dueDate" value={form.dueDate} type="date" editCtx={editCtx} />
               </div>
             </div>
             <div className="modal-header-right">
@@ -473,7 +477,7 @@ export default function TaskModal({ tasks, careTeam, users, editId, onClose, use
           {/* Description */}
           <div className="fr">
             <label>Description</label>
-            <InlineTextarea field="description" value={form.description} placeholder="Additional details…" />
+            <InlineTextarea field="description" value={form.description} placeholder="Additional details…" editCtx={editCtx} />
           </div>
 
           {/* Doctors & Assignee */}


### PR DESCRIPTION
InlineField/InlineTextarea/InlineSelect were defined inside their parent
components (MedRow, AptDetailModal, TaskModal). React treated them as new
component types on every render, unmounting and remounting the input on
each keystroke — resetting cursor position to 0 and re-triggering mobile
keyboard auto-capitalization. Moved all inline edit components to module
scope and pass edit state via an editCtx prop object.

https://claude.ai/code/session_014XoBjYZfSm8mSspagcoWNP