### PR TITLE
Make supply status thresholds more conservative

### DIFF
--- a/client/src/components/meds/KPIRow.jsx
+++ b/client/src/components/meds/KPIRow.jsx
@@ -17,7 +17,7 @@ export default function KPIRow({ meds }) {
       <div className="kpi kpi-urgent">
         <div className="kpi-num">{urgent.length}</div>
         <div className="kpi-lbl">
-          <span className="lbl-full">Refill within 3 days</span>
+          <span className="lbl-full">Refill within 7 days</span>
           <span className="lbl-short">Urgent</span>
         </div>
         {urgent.length > 0 && (
@@ -27,8 +27,8 @@ export default function KPIRow({ meds }) {
       <div className="kpi kpi-soon">
         <div className="kpi-num">{soon.length}</div>
         <div className="kpi-lbl">
-          <span className="lbl-full">Refill this week</span>
-          <span className="lbl-short">This week</span>
+          <span className="lbl-full">Refill in 2 weeks</span>
+          <span className="lbl-short">2 weeks</span>
         </div>
       </div>
       <div className="kpi kpi-ok">

--- a/client/src/components/meds/MedGroupSection.jsx
+++ b/client/src/components/meds/MedGroupSection.jsx
@@ -5,7 +5,7 @@ import MedStockedCollapsed from './MedStockedCollapsed'
 
 const GROUP_META = {
   urgent: { label: 'Refill urgently', variant: 'urgent', defaultOpen: true },
-  soon:   { label: 'Refill this week', variant: 'soon',   defaultOpen: true },
+  soon:   { label: 'Refill in 2 weeks', variant: 'soon',   defaultOpen: true },
   ok:     { label: 'Stocked up',       variant: 'ok',     defaultOpen: false },
 }
 

--- a/client/src/components/meds/MedicationsView.jsx
+++ b/client/src/components/meds/MedicationsView.jsx
@@ -61,8 +61,8 @@ export default function MedicationsView({ meds, careTeam }) {
           <div className="filter-tabs">
             {[
               ['all',    'All'],
-              ['urgent', '≤ 3d'],
-              ['soon',   '4–7d'],
+              ['urgent', '≤ 7d'],
+              ['soon',   '8–14d'],
               ['ok',     'Stocked'],
             ].map(([f, label]) => (
               <button

--- a/client/src/lib/medUtils.js
+++ b/client/src/lib/medUtils.js
@@ -69,12 +69,12 @@ export function getRefillDate(m) {
   return pillsNow(m).runOutDate
 }
 
-const REFILL_LEAD = 7
+const REFILL_LEAD = 14
 
 export function supplyStatus(m) {
   const p = pillsNow(m)
   if (p.rem <= 0) return 'urgent'
-  if (p.daysToZero <= 3) return 'urgent'
+  if (p.daysToZero <= 7) return 'urgent'
   if (p.daysToZero <= REFILL_LEAD) return 'soon'
   return 'ok'
 }
@@ -84,7 +84,7 @@ export function supplyStatusLabel(m) {
   if (p.rem <= 0) return 'Out of pills'
   const d = p.daysToZero
   if (d <= 0) return 'Out of pills'
-  if (d <= 3) return d === 1 ? 'Refill today' : 'Refill in ' + d + 'd'
+  if (d <= 7) return d === 1 ? 'Refill today' : 'Refill in ' + d + 'd'
   if (d <= REFILL_LEAD) return 'Refill in ' + d + 'd'
   return 'OK — ' + d + 'd left'
 }

--- a/client/src/test/KPIRow.test.jsx
+++ b/client/src/test/KPIRow.test.jsx
@@ -14,7 +14,7 @@ afterEach(() => {
 })
 
 const urgentMed   = { id: '1', name: 'Metformin', filledDate: '2026-03-29', supply: 3, frequency: 1 }
-const soonMed     = { id: '2', name: 'Lisinopril', filledDate: '2026-03-31', supply: 5, frequency: 1 }
+const soonMed     = { id: '2', name: 'Lisinopril', filledDate: '2026-03-31', supply: 10, frequency: 1 }
 const okMed       = { id: '3', name: 'Atorvastatin', filledDate: '2026-03-31', supply: 30, frequency: 1 }
 
 describe('KPIRow', () => {
@@ -26,7 +26,7 @@ describe('KPIRow', () => {
 
   it('shows correct urgent count', () => {
     render(<KPIRow meds={[urgentMed, soonMed, okMed]} />)
-    const urgentCard = screen.getByText('Refill within 3 days').closest('.kpi-urgent')
+    const urgentCard = screen.getByText('Refill within 7 days').closest('.kpi-urgent')
     expect(urgentCard.querySelector('.kpi-num').textContent).toBe('1')
   })
 
@@ -37,9 +37,9 @@ describe('KPIRow', () => {
 
   it('shows 0 urgent when all meds are stocked', () => {
     render(<KPIRow meds={[okMed]} />)
-    expect(screen.getByText('Refill within 3 days')).toBeInTheDocument()
+    expect(screen.getByText('Refill within 7 days')).toBeInTheDocument()
     // Urgent count should be 0
-    const urgentCard = screen.getByText('Refill within 3 days').closest('.kpi-urgent')
+    const urgentCard = screen.getByText('Refill within 7 days').closest('.kpi-urgent')
     expect(urgentCard.querySelector('.kpi-num').textContent).toBe('0')
   })
 

--- a/client/src/test/MedsTable.test.jsx
+++ b/client/src/test/MedsTable.test.jsx
@@ -43,7 +43,7 @@ describe('MedsTable', () => {
 
   it('renders status pills', () => {
     render(<MedsTable meds={[med2]} filter="all" search="" onEdit={noop} />)
-    // med2 has 5 days supply → 'soon'
+    // med2 has 5 days supply → 'urgent'
     expect(screen.getByText(/Refill in/)).toBeInTheDocument()
   })
 

--- a/client/src/test/medUtils.test.js
+++ b/client/src/test/medUtils.test.js
@@ -115,17 +115,17 @@ describe('supplyStatus', () => {
     expect(supplyStatus(med)).toBe('urgent')
   })
 
-  it('returns urgent when ≤3 days remain', () => {
+  it('returns urgent when ≤7 days remain', () => {
     const med = { filledDate: '2026-03-29', supply: 30, frequency: 10 } // ~2 days left
     expect(supplyStatus(med)).toBe('urgent')
   })
 
-  it('returns soon when 4–7 days remain', () => {
-    const med = { filledDate: '2026-03-31', supply: 5, frequency: 1 } // 5 days
+  it('returns soon when 8–14 days remain', () => {
+    const med = { filledDate: '2026-03-31', supply: 10, frequency: 1 } // 10 days
     expect(supplyStatus(med)).toBe('soon')
   })
 
-  it('returns ok when 8+ days remain', () => {
+  it('returns ok when 15+ days remain', () => {
     const med = { filledDate: '2026-03-31', supply: 30, frequency: 1 } // 30 days
     expect(supplyStatus(med)).toBe('ok')
   })


### PR DESCRIPTION
Urgent window expands from ≤3 days to ≤7 days; soon window expands
from 4–7 days to 8–14 days, giving more lead time to request refills.

https://claude.ai/code/session_018BhgVGkiTvQPgm8KZCQnJK