### PR TITLE
Fix duplicate push notifications

### DIFF
--- a/client/public/firebase-messaging-sw.js
+++ b/client/public/firebase-messaging-sw.js
@@ -16,13 +16,12 @@ firebase.initializeApp({
 const messaging = firebase.messaging();
 
 messaging.onBackgroundMessage((payload) => {
-  const { title, body } = payload.notification;
+  const { title, body } = payload.data;
   self.registration.showNotification(title, {
     body,
     icon: '/favicon.png',
     badge: '/favicon.png',
     tag: 'med-supply-alert',
-    renotify: true,
     data: { url: '/' },
   });
 });

--- a/functions/index.js
+++ b/functions/index.js
@@ -88,14 +88,8 @@ exports.checkMedSupply = onSchedule(
     const tokens = tokenEntries.map((e) => e.token);
     const response = await messaging.sendEachForMulticast({
       tokens,
-      notification: { title, body },
+      data: { title, body },
       webpush: {
-        notification: {
-          icon: `${APP_URL}/favicon.png`,
-          badge: `${APP_URL}/favicon.png`,
-          tag: "med-supply-alert",
-          renotify: true,
-        },
         fcmOptions: { link: APP_URL },
       },
     });


### PR DESCRIPTION
iOS auto-displays notifications from the FCM `notification` payload before the service worker runs, then `onBackgroundMessage` calls `showNotification` a second time — two identical notifications from a single push.

**Fix:** switch to a data-only FCM message so iOS has nothing to auto-display, leaving `onBackgroundMessage` as the sole place the notification is shown.

- `functions/index.js`: removed `notification` and `webpush.notification` fields, added `data: { title, body }`
- `firebase-messaging-sw.js`: read from `payload.data` instead of `payload.notification`, dropped `renotify: true`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdTUxxBMzEa6w6rM23caLa)_