### PR TITLE
Move Doctors and theme toggle into profile dropdown

### DIFF
--- a/client/e2e/profile-dropdown.spec.js
+++ b/client/e2e/profile-dropdown.spec.js
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+const AUTH_URL = '/?testUser=1';
+
+test.describe('profile dropdown', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(AUTH_URL);
+    // Firebase keeps persistent connections open so networkidle never fires.
+    // Wait for the topbar to confirm the app has rendered.
+    await page.waitForSelector('.topbar-menu-wrap', { timeout: 15_000 });
+  });
+
+  test('opens when profile button is clicked', async ({ page }) => {
+    await page.getByRole('button', { name: /Test User|▾/ }).click();
+    await expect(page.locator('.topbar-menu')).toBeVisible();
+  });
+
+  test('contains Doctors item that navigates to Care Team', async ({ page }) => {
+    await page.getByRole('button', { name: /Test User|▾/ }).click();
+    const doctorsBtn = page.getByRole('button', { name: 'Doctors' });
+    await expect(doctorsBtn).toBeVisible();
+    await doctorsBtn.click();
+    // Dropdown closes and Care Team view renders
+    await expect(page.locator('.topbar-menu')).not.toBeVisible();
+    await expect(page.locator('.back-bar')).toContainText('Care Team');
+  });
+
+  test('contains theme toggle that switches between light and dark mode', async ({ page }) => {
+    // Starts in dark mode (default)
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+    await page.getByRole('button', { name: /Test User|▾/ }).click();
+    const themeBtn = page.getByRole('button', { name: 'Light mode' });
+    await expect(themeBtn).toBeVisible();
+    await themeBtn.click();
+
+    // Theme switches to light; dropdown stays open and label flips to "Dark mode"
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+    await expect(page.getByRole('button', { name: 'Dark mode' })).toBeVisible();
+  });
+
+  test('closes when clicking outside', async ({ page }) => {
+    await page.getByRole('button', { name: /Test User|▾/ }).click();
+    await expect(page.locator('.topbar-menu')).toBeVisible();
+    await page.locator('.brand').click();
+    await expect(page.locator('.topbar-menu')).not.toBeVisible();
+  });
+
+  test('contains Notifications and Sign out items', async ({ page }) => {
+    await page.getByRole('button', { name: /Test User|▾/ }).click();
+    await expect(page.getByRole('button', { name: /Notifications/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign out' })).toBeVisible();
+  });
+});

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,8 +2,14 @@ import { useAuth } from './hooks/useAuth'
 import LoginScreen from './components/LoginScreen'
 import MainApp from './components/MainApp'
 
+const DEV_TEST_USER = import.meta.env.DEV &&
+  new URLSearchParams(window.location.search).get('testUser') === '1'
+    ? { uid: 'test-uid', displayName: 'Test User', email: 'test@example.com', photoURL: null }
+    : null
+
 export default function App() {
-  const user = useAuth()
+  const firebaseUser = useAuth()
+  const user = DEV_TEST_USER ?? firebaseUser
 
   if (user === undefined) {
     return (

--- a/client/src/components/MainApp.jsx
+++ b/client/src/components/MainApp.jsx
@@ -79,9 +79,6 @@ export default function MainApp({ user }) {
           <button className="btn-ask-ai" onClick={() => setAskAiOpen(true)}>
             <span className="ask-ai-icon-sm">?</span> Ask AI
           </button>
-          <button className="btn-ghost" onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')} title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
-            {theme === 'dark' ? '☀' : '☽'}
-          </button>
           <div className="topbar-menu-wrap" ref={userMenuRef}>
             <button className="btn-ghost topbar-user-btn" onClick={() => setUserMenuOpen(o => !o)}>
               {user.photoURL
@@ -102,6 +99,14 @@ export default function MainApp({ user }) {
                     {notifPermission === 'denied' && 'Blocked'}
                     {notifPermission === 'unsupported' && 'Unavailable'}
                   </span>
+                </button>
+                <div className="menu-divider" />
+                <button className="menu-item" onClick={() => { setActiveTab('care-team'); setUserMenuOpen(false) }}>
+                  <span className="menu-item-label">Doctors</span>
+                </button>
+                <button className="menu-item menu-item-notif" onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')}>
+                  <span className="menu-item-label">{theme === 'dark' ? 'Light mode' : 'Dark mode'}</span>
+                  <span>{theme === 'dark' ? '☀' : '☽'}</span>
                 </button>
                 <div className="menu-divider" />
                 <button className="menu-item" onClick={() => { signOut(auth); setUserMenuOpen(false) }}>


### PR DESCRIPTION
## Summary
- Removes the standalone light/dark mode button from the topbar
- Adds **Doctors** (→ Care Team view) and **Light/Dark mode toggle** into the profile dropdown menu
- Adds a dev-only `?testUser=1` bypass in `App.jsx` (guarded by `import.meta.env.DEV`) so Playwright can reach authenticated UI without real Firebase credentials
- Adds 5 Playwright e2e tests covering the profile dropdown: open/close, Doctors navigation, theme toggle, click-outside dismiss, and menu item presence

## Test plan
- [x] All 8 Playwright e2e tests pass
- [x] Verified on Vercel preview deployment

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)