### PR TITLE
Always derive refill date from computed runout

### DIFF
--- a/client/src/components/meds/MedRow.jsx
+++ b/client/src/components/meds/MedRow.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { pillsNow, supplyStatus, supplyStatusLabel, refillStatusLabel, pillStatusClass, fmtDate, freqLabel } from '../../lib/medUtils'
+import { pillsNow, supplyStatus, supplyStatusLabel, refillStatusLabel, pillStatusClass, fmtDate, freqLabel, getRefillDate } from '../../lib/medUtils'
 import { saveMed, markRefilled, updateRefillStatus, deactivateMed, reactivateMed } from '../../lib/firestore'
 import PersonChip from '../PersonChip'
 
@@ -130,7 +130,8 @@ export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand })
   const pillSt = p.rem <= 0 ? 'empty' : s
   const fl = freqLabel(m)
   const sub = [m.dose, m.rxNum ? 'Rx ' + m.rxNum : '', fl].filter(Boolean).join(' · ')
-  const rd = m.refillDate ? fmtDate(m.refillDate) : (p.runOutDate ? fmtDate(p.runOutDate) : '—')
+  const rdDate = getRefillDate(m)
+  const rd = rdDate ? fmtDate(rdDate) : '—'
   const rs = m.refillStatus || null
 
   useEffect(() => {

--- a/client/src/components/meds/MedsTable.jsx
+++ b/client/src/components/meds/MedsTable.jsx
@@ -73,7 +73,8 @@ export default function MedsTable({ meds, filter, search, onEdit }) {
             const pillSt = p.rem <= 0 ? 'empty' : s
             const fl = freqLabel(m)
             const sub = [m.dose, m.rxNum ? 'Rx ' + m.rxNum : '', fl].filter(Boolean).join(' · ')
-            const rd = m.refillDate ? fmtDate(m.refillDate) : (p.runOutDate ? fmtDate(p.runOutDate) + ' *' : '—')
+            const rdDate = getRefillDate(m)
+            const rd = rdDate ? fmtDate(rdDate) : '—'
 
             return (
               <tr key={m.id} onClick={() => onEdit(m.id)} style={{ cursor: 'pointer' }}>

--- a/client/src/lib/medUtils.js
+++ b/client/src/lib/medUtils.js
@@ -70,7 +70,6 @@ export function pillsNow(m) {
 }
 
 export function getRefillDate(m) {
-  if (m.refillDate) return new Date(m.refillDate + 'T00:00:00')
   return pillsNow(m).runOutDate
 }
 


### PR DESCRIPTION
The stored med.refillDate override is no longer consulted at display
time. getRefillDate() now returns pillsNow(m).runOutDate
unconditionally, and MedRow/MedsTable use the helper instead of
inlining the override fallback.

https://claude.ai/code/session_01VofPirK643JuAvdFiZRd8e