### PR TITLE
Always compute refill date and align date formatting app-wide

### DIFF
--- a/client/src/components/DashboardView.jsx
+++ b/client/src/components/DashboardView.jsx
@@ -1,4 +1,4 @@
-import { supplyStatus } from '../lib/medUtils'
+import { supplyStatus, fmtShortDate } from '../lib/medUtils'
 import { aptStatus, fmtAptDateBlock, fmtAptTime } from '../lib/aptUtils'
 import DiseaseTimelineCard from './timeline/DiseaseTimelineCard'
 import PersonChip from './PersonChip'
@@ -13,12 +13,6 @@ function isOverdue(dueDate) {
   today.setHours(0, 0, 0, 0)
   const [y, m, d] = dueDate.split('-').map(Number)
   return new Date(y, m - 1, d) < today
-}
-
-function fmtShortDate(dueDate) {
-  if (!dueDate) return null
-  const [y, m, d] = dueDate.split('-').map(Number)
-  return new Date(y, m - 1, d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
 const DAY_ABBR = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -36,8 +30,7 @@ function getWeekRange() {
 }
 
 function fmtWeekRange(start, end) {
-  const opts = { month: 'short', day: 'numeric' }
-  return `${start.toLocaleDateString('en-US', opts)} – ${end.toLocaleDateString('en-US', opts)}`
+  return `${fmtShortDate(start)} – ${fmtShortDate(end)}`
 }
 
 // ── Summary alert bar (desktop only) ────────────────────────────────────────

--- a/client/src/components/apts/AgendaGroups.jsx
+++ b/client/src/components/apts/AgendaGroups.jsx
@@ -1,5 +1,5 @@
 import { aptStatus } from '../../lib/aptUtils'
-import { today } from '../../lib/medUtils'
+import { today, fmtShortDate } from '../../lib/medUtils'
 import AptCard from './AptCard'
 
 export default function AgendaGroups({ apts, search, noteById, onView, pastExpanded, onPastExpand, careTeam = [] }) {
@@ -20,8 +20,8 @@ export default function AgendaGroups({ apts, search, noteById, onView, pastExpan
   const t = today()
   const start = new Date(t); start.setDate(t.getDate() + 1)
   const end   = new Date(t); end.setDate(t.getDate() + 7)
-  const weekRange = `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}–${end.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`
-  const todayStr = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  const weekRange = `${fmtShortDate(start)}–${fmtShortDate(end)}`
+  const todayStr = fmtShortDate(new Date())
 
   if (!rows.length) {
     return (

--- a/client/src/components/meds/MedModal.jsx
+++ b/client/src/components/meds/MedModal.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { saveMed } from '../../lib/firestore'
 import { useIsMobile } from '../../hooks/useIsMobile'
-import { freqPerDay } from '../../lib/medUtils'
+import { freqPerDay, fmtDate } from '../../lib/medUtils'
 
 const EMPTY = {
   name: '', dose: '', frequencyPreset: 'once-daily',
@@ -109,7 +109,7 @@ export default function MedModal({ careTeam = [], onClose }) {
         d.setDate(d.getDate() + days)
         return (
           <div className="fr-hint" style={{ marginBottom: 4 }}>
-            Runs out approx. {d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+            Runs out approx. {fmtDate(d)}
           </div>
         )
       })()}

--- a/client/src/components/meds/MedRow.jsx
+++ b/client/src/components/meds/MedRow.jsx
@@ -31,6 +31,7 @@ function InlineField({ field, value, type = 'text', placeholder = '', editCtx })
       />
     )
   }
+  const display = type === 'date' && value ? fmtDate(value) : value
   return (
     <span
       className="inline-val"
@@ -38,7 +39,7 @@ function InlineField({ field, value, type = 'text', placeholder = '', editCtx })
       onClick={e => { e.stopPropagation(); startEdit(field, value) }}
       onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
     >
-      {value || <span style={{ color: 'var(--text3)' }}>—</span>}
+      {display || <span style={{ color: 'var(--text3)' }}>—</span>}
     </span>
   )
 }

--- a/client/src/components/tasks/TaskModal.jsx
+++ b/client/src/components/tasks/TaskModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { saveTask, updateTaskFields, addComment, deleteComment, newId } from '../../lib/firestore'
+import { fmtShortDate } from '../../lib/medUtils'
 import { useIsMobile } from '../../hooks/useIsMobile'
 
 const STATUSES = ['todo', 'in-progress', 'done']
@@ -369,11 +370,6 @@ export default function TaskModal({ tasks, careTeam, users, editId, defaultParen
       d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
   }
 
-  function formatDue(dueDate) {
-    if (!dueDate) return null
-    const [y, m, d] = dueDate.split('-').map(Number)
-    return new Date(y, m - 1, d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-  }
 
   // ── Inline edit helpers (edit mode only) ───────────────────────────────────
 
@@ -479,7 +475,7 @@ export default function TaskModal({ tasks, careTeam, users, editId, defaultParen
                 <span className={`subtask-modal-dot subtask-modal-dot-${childStatus.replace('-', '')}`} />
                 <span className="task-subtask-title">{child.title}</span>
                 {child.dueDate && (
-                  <span className="task-subtask-due">{formatDue(child.dueDate)}</span>
+                  <span className="task-subtask-due">{fmtShortDate(child.dueDate)}</span>
                 )}
               </li>
             )

--- a/client/src/components/tasks/TasksView.jsx
+++ b/client/src/components/tasks/TasksView.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { updateTaskAssignees, delTask } from '../../lib/firestore'
+import { fmtShortDate } from '../../lib/medUtils'
 import TaskModal from './TaskModal'
 import { filterByPerson } from '../MainApp'
 import PersonChip from '../PersonChip'
@@ -26,12 +27,6 @@ const CATEGORIES = [
 
 function getStatus(task) {
   return task.status || (task.done ? 'done' : 'todo')
-}
-
-function formatDue(dueDate) {
-  if (!dueDate) return null
-  const [y, m, d] = dueDate.split('-').map(Number)
-  return new Date(y, m - 1, d).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
 function isOverdue(dueDate) {
@@ -144,7 +139,7 @@ export default function TasksView({ tasks, careTeam, users, user, personFilter, 
         <span className="subtask-title">{child.title}</span>
         {child.dueDate && (
           <span className={`subtask-due${overdue ? ' overdue' : ''}`}>
-            {overdue ? '⚠ ' : ''}{formatDue(child.dueDate)}
+            {overdue ? '⚠ ' : ''}{fmtShortDate(child.dueDate)}
           </span>
         )}
       </li>
@@ -175,7 +170,7 @@ export default function TasksView({ tasks, careTeam, users, user, personFilter, 
               ))}
               {task.dueDate && (
                 <span className={`task-due${overdue ? ' overdue' : ''}`}>
-                  {overdue ? '⚠ ' : ''}{formatDue(task.dueDate)}
+                  {overdue ? '⚠ ' : ''}{fmtShortDate(task.dueDate)}
                 </span>
               )}
               {(task.comments?.length > 0) && (

--- a/client/src/components/timeline/MilestoneRow.jsx
+++ b/client/src/components/timeline/MilestoneRow.jsx
@@ -1,4 +1,5 @@
 import MilestoneTag from './MilestoneTag'
+import { fmtDate, fmtShortDate } from '../../lib/medUtils'
 
 const DOT_STYLE = {
   green:  { background: '#3cbf7a' },
@@ -8,19 +9,10 @@ const DOT_STYLE = {
   amber:  { background: '#e09340' },
 }
 
-function fmtDate(dateStr) {
-  const [y, m, d] = dateStr.split('-').map(Number)
-  const dt = new Date(y, m - 1, d)
-  return {
-    monthDay: dt.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-    year: String(y),
-    full: dt.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
-  }
-}
-
 // Desktop layout: date left col | dot+line center | content right
 function DesktopRow({ milestone, showConnector }) {
-  const { monthDay, year } = fmtDate(milestone.date)
+  const monthDay = fmtShortDate(milestone.date)
+  const year = milestone.date.split('-')[0]
   const dotStyle = DOT_STYLE[milestone.dot] || DOT_STYLE.filled
   return (
     <div className="tl-row">
@@ -48,7 +40,7 @@ function DesktopRow({ milestone, showConnector }) {
 
 // Mobile layout: dot left | content block (date inline at top)
 function MobileRow({ milestone }) {
-  const { full } = fmtDate(milestone.date)
+  const full = fmtDate(milestone.date)
   const dotStyle = DOT_STYLE[milestone.dot] || DOT_STYLE.filled
   return (
     <div className="tl-row-mobile">

--- a/client/src/lib/medUtils.js
+++ b/client/src/lib/medUtils.js
@@ -116,3 +116,9 @@ export function fmtDate(d) {
   if (typeof d === 'string') d = new Date(d + 'T00:00:00')
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
 }
+
+export function fmtShortDate(d) {
+  if (!d) return null
+  if (typeof d === 'string') d = new Date(d + 'T00:00:00')
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}


### PR DESCRIPTION
## Summary
- `getRefillDate()` always returns the computed runout date; the stored `med.refillDate` override is no longer consulted at display time. `MedRow` and `MedsTable` now call the helper instead of inlining the override fallback.
- `InlineField` with `type="date"` displays values via `fmtDate`, so "Last filled" reads `Apr 16, 2026` to match "Runs out". The underlying `<input type="date">` still uses ISO when editing.
- Added `fmtShortDate` next to `fmtDate` in `lib/medUtils.js` and routed five inline `toLocaleDateString(...)` duplicates through the shared helpers (`TasksView`, `TaskModal`, `DashboardView`, `AgendaGroups`, `MedModal`, `MilestoneRow`).

## Format conventions (now centralized)
- **Detail surfaces** → `Apr 16, 2026` (full year): med Last filled / Runs out, milestone full, MedModal "Runs out approx.".
- **Compact lists / chips** → `Apr 16` (no year): dashboard, tasks, agenda week range, milestone monthDay column.

Appointment-specific helpers (`fmtAptDateBlock`, `fmtAptTime`, AptDetailModal long-weekday header) are intentionally untouched.

## Test plan
- [x] `npm run test:run` — 62 unit tests pass
- [x] `npm run build` — clean build
- [ ] Smoke: open a med, confirm Last filled and Runs out both render `Mon DD, YYYY`
- [ ] Smoke: dashboard / tasks / agenda still show `Mon DD` chips
- [ ] `npm run test:e2e` before merge

https://claude.ai/code/session_01VofPirK643JuAvdFiZRd8e

---
_Generated by [Claude Code](https://claude.ai/code/session_01VofPirK643JuAvdFiZRd8e)_