### PR TITLE
Refill confirmation modal and full-screen med detail

### DIFF
--- a/client/e2e/medications.spec.js
+++ b/client/e2e/medications.spec.js
@@ -61,11 +61,18 @@ test.describe('medications', () => {
     await expect(page.locator('.med-row-main').first()).toBeVisible();
   });
 
-  test('expand drawer shows inline fields', async ({ page }) => {
-    const name = `[e2e] ExpandMed ${Date.now()}`;
+  // Detail modal locator scoped to detail (excludes the Refill modal whose title starts with "Refill ")
+  function detailModal(page, name) {
+    return page.locator('[role="dialog"]', { hasText: name })
+      .filter({ has: page.locator('.med-drawer-details') });
+  }
+
+  test('open med detail modal shows inline fields', async ({ page }) => {
+    const name = `[e2e] DetailMed ${Date.now()}`;
     await addMed(page, name);
     await page.locator('.med-row-main', { hasText: name }).click();
-    await expect(page.locator('.med-drawer.open')).toBeVisible();
+    await expect(detailModal(page, name)).toBeVisible();
+    await expect(detailModal(page, name).locator('.med-drawer-details')).toBeVisible();
   });
 
   test('inline edit name autosaves', async ({ page }) => {
@@ -73,10 +80,11 @@ test.describe('medications', () => {
     const newName = `[e2e] InlineEdited ${Date.now()}`;
     await addMed(page, name);
     await page.locator('.med-row-main', { hasText: name }).click();
-    await page.waitForSelector('.med-drawer.open', { timeout: 5_000 });
-    await page.locator('.med-drawer.open .inline-val').first().click();
-    await page.locator('.med-drawer.open .inline-input').first().fill(newName);
-    await page.locator('.med-drawer.open .inline-input').first().press('Enter');
+    const modal = detailModal(page, name);
+    await modal.waitFor({ timeout: 5_000 });
+    await modal.locator('.inline-val').first().click();
+    await modal.locator('.inline-input').first().fill(newName);
+    await modal.locator('.inline-input').first().press('Enter');
     await page.waitForSelector('.autosave-pill.saved', { timeout: 15_000 });
     await expect(page.locator('.autosave-pill.saved')).toBeVisible();
   });
@@ -84,61 +92,59 @@ test.describe('medications', () => {
   test('refill request updates badge', async ({ page }) => {
     const name = `[e2e] RefillMed ${Date.now()}`;
     await addMed(page, name);
-    const row = page.locator('.med-row', { hasText: name });
-    await row.locator('.med-row-main').click();
-    await row.locator('.med-drawer.open').waitFor({ timeout: 5_000 });
-    await row.locator('.med-drawer-actions').getByRole('button', { name: 'Place request' }).click();
+    await page.locator('.med-row-main', { hasText: name }).click();
+    const modal = detailModal(page, name);
+    await modal.waitFor({ timeout: 5_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Place request' }).click();
     // Wait for next workflow button — proves write succeeded and listener updated UI
-    await row.locator('.med-drawer-actions').getByRole('button', { name: 'Ready for pickup' }).waitFor({ timeout: 15_000 });
-    await expect(row.locator('.med-row-main')).toContainText(/Requested/);
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Ready for pickup' }).waitFor({ timeout: 15_000 });
+    // Close modal and check the row badge
+    await modal.getByRole('button', { name: 'Close' }).click();
+    await expect(page.locator('.med-row-main', { hasText: name })).toContainText(/Requested/);
   });
 
   test('mark refilled clears refill badge', async ({ page }) => {
     const name = `[e2e] MarkRefill ${Date.now()}`;
     await addMed(page, name);
-    const row = page.locator('.med-row', { hasText: name });
-    await row.locator('.med-row-main').click();
-    await row.locator('.med-drawer.open').waitFor({ timeout: 5_000 });
+    await page.locator('.med-row-main', { hasText: name }).click();
+    const modal = detailModal(page, name);
+    await modal.waitFor({ timeout: 5_000 });
     // Step through workflow: request → ready-pickup → picked-up → mark refilled
-    // Wait for each next-step button to confirm the write succeeded before proceeding
-    await row.locator('.med-drawer-actions').getByRole('button', { name: 'Place request' }).click();
-    await row.locator('.med-drawer-actions').getByRole('button', { name: 'Ready for pickup' }).waitFor({ timeout: 15_000 });
-    await row.locator('.med-drawer-actions').getByRole('button', { name: 'Ready for pickup' }).click();
-    await row.locator('.med-drawer-actions').getByRole('button', { name: 'Picked up' }).waitFor({ timeout: 15_000 });
-    await row.locator('.med-drawer-actions').getByRole('button', { name: 'Picked up' }).click();
-    await row.locator('.med-drawer-actions').getByRole('button', { name: 'Mark refilled' }).waitFor({ timeout: 15_000 });
-    await row.locator('.med-drawer-actions').getByRole('button', { name: 'Mark refilled' }).click();
-    // After marking refilled the med moves to the collapsed stocked group — expand it first
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Place request' }).click();
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Ready for pickup' }).waitFor({ timeout: 15_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Ready for pickup' }).click();
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Picked up' }).waitFor({ timeout: 15_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Picked up' }).click();
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Mark refilled' }).waitFor({ timeout: 15_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Mark refilled' }).click();
+    // Refill confirmation modal opens — confirm with current values
+    const refillModal = page.locator('[role="dialog"]', { hasText: `Refill ${name}` });
+    await refillModal.waitFor({ timeout: 5_000 });
+    await refillModal.getByRole('button', { name: /Confirm refill/ }).click();
+    // After confirming, both modals close and the med moves to the collapsed stocked group
     await page.locator('.med-group-ok').waitFor({ timeout: 15_000 });
     await page.locator('.med-group-ok .stk-show-btn').click();
     const stockedRow = page.locator('.med-group-ok .med-row', { hasText: name });
     await stockedRow.locator('.med-row-main').click();
-    await stockedRow.locator('.med-drawer.open').waitFor({ timeout: 5_000 });
-    await expect(stockedRow.locator('.med-drawer-actions').getByRole('button', { name: 'Place request' })).toBeVisible();
+    const reopened = detailModal(page, name);
+    await reopened.waitFor({ timeout: 5_000 });
+    await expect(reopened.locator('.med-drawer-actions').getByRole('button', { name: 'Place request' })).toBeVisible();
     await expect(stockedRow.locator('.med-row-main')).not.toContainText(/Requested/);
   });
 
-  async function deactivateRow(row) {
-    // ⋯ menu is hidden on mobile — use drawer button instead
-    if (await row.locator('.med-menu-btn').isVisible()) {
-      await row.locator('.med-menu-btn').click();
-      await row.locator('.med-menu-pop').waitFor({ timeout: 3_000 });
-      await row.locator('.med-menu-pop').getByRole('button', { name: 'Deactivate' }).click();
-      await row.locator('.med-menu-pop').getByRole('button', { name: 'Confirm deactivate?' }).waitFor({ timeout: 5_000 });
-      await row.locator('.med-menu-pop').getByRole('button', { name: 'Confirm deactivate?' }).click();
-    } else {
-      await row.locator('.med-row-main').click();
-      await row.locator('.med-drawer.open').waitFor({ timeout: 5_000 });
-      await row.locator('.drawer-deactivate').click();
-      await row.locator('.drawer-deactivate.danger').waitFor({ timeout: 3_000 });
-      await row.locator('.drawer-deactivate.danger').click();
-    }
+  async function deactivateMed(page, name) {
+    await page.locator('.med-row-main', { hasText: name }).click();
+    const modal = detailModal(page, name);
+    await modal.waitFor({ timeout: 5_000 });
+    await modal.locator('.drawer-deactivate').click();
+    await modal.locator('.drawer-deactivate.danger').waitFor({ timeout: 3_000 });
+    await modal.locator('.drawer-deactivate.danger').click();
   }
 
   test('deactivate moves med to inactive group', async ({ page }) => {
     const name = `[e2e] DeactMed ${Date.now()}`;
     await addMed(page, name);
-    await deactivateRow(page.locator('.med-row', { hasText: name }));
+    await deactivateMed(page, name);
     // Inactive group starts collapsed — expand it first
     await page.locator('.med-group-inactive').waitFor({ timeout: 15_000 });
     await page.locator('.med-group-inactive .med-group-toggle').click();
@@ -148,15 +154,14 @@ test.describe('medications', () => {
   test('reactivate moves med back to active groups', async ({ page }) => {
     const name = `[e2e] ReactMed ${Date.now()}`;
     await addMed(page, name);
-    await deactivateRow(page.locator('.med-row', { hasText: name }));
-    // Inactive group starts collapsed — expand it first
+    await deactivateMed(page, name);
     await page.locator('.med-group-inactive').waitFor({ timeout: 15_000 });
     await page.locator('.med-group-inactive .med-group-toggle').click();
-    // Reactivate via drawer on the inactive row (Reactivate button is always in drawer)
     const inactiveRow = page.locator('.med-group-inactive .med-row', { hasText: name });
     await inactiveRow.locator('.med-row-main').click();
-    await inactiveRow.locator('.med-drawer.open').waitFor({ timeout: 5_000 });
-    await inactiveRow.locator('.med-drawer-actions').getByRole('button', { name: 'Reactivate' }).click();
+    const modal = detailModal(page, name);
+    await modal.waitFor({ timeout: 5_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Reactivate' }).click();
     await page.waitForSelector(`.med-row:not(.med-row-inactive) .med-row-main >> text=${name}`, { timeout: 15_000 });
     await expect(page.locator('.med-row:not(.med-row-inactive) .med-row-main', { hasText: name })).toBeVisible();
   });

--- a/client/src/components/meds/MedDetailModal.jsx
+++ b/client/src/components/meds/MedDetailModal.jsx
@@ -1,0 +1,325 @@
+import { useState, useRef, useEffect } from 'react'
+import { fmtDate, getRefillDate } from '../../lib/medUtils'
+import { saveMed, updateRefillStatus, deactivateMed, reactivateMed } from '../../lib/firestore'
+import { useIsMobile } from '../../hooks/useIsMobile'
+import PersonChip from '../PersonChip'
+import RefillModal from './RefillModal'
+
+const PRESETS = [
+  { value: 'once-daily',      label: 'Once daily' },
+  { value: 'twice-daily',     label: 'Twice daily' },
+  { value: 'every-other-day', label: 'Every other day' },
+  { value: 'as-needed',       label: 'As needed' },
+  { value: 'custom',          label: 'Custom…' },
+]
+
+function InlineField({ field, value, type = 'text', placeholder = '', editCtx }) {
+  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
+  if (editingField === field) {
+    return (
+      <input
+        className="inline-input"
+        type={type}
+        value={draftValue}
+        autoFocus
+        onChange={e => setDraftValue(e.target.value)}
+        onBlur={() => commitEdit(field, draftValue)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') commitEdit(field, draftValue)
+          if (e.key === 'Escape') cancelEdit()
+        }}
+        placeholder={placeholder}
+      />
+    )
+  }
+  const display = type === 'date' && value ? fmtDate(value) : value
+  return (
+    <span
+      className="inline-val"
+      tabIndex={0}
+      onClick={() => startEdit(field, value)}
+      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
+    >
+      {display || <span style={{ color: 'var(--text3)' }}>—</span>}
+    </span>
+  )
+}
+
+function InlineTextarea({ field, value, placeholder = '', editCtx }) {
+  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
+  if (editingField === field) {
+    return (
+      <textarea
+        className="inline-input"
+        rows={3}
+        value={draftValue}
+        autoFocus
+        onChange={e => setDraftValue(e.target.value)}
+        onBlur={() => commitEdit(field, draftValue)}
+        onKeyDown={e => e.key === 'Escape' && cancelEdit()}
+        placeholder={placeholder}
+      />
+    )
+  }
+  return (
+    <span
+      className="inline-val"
+      style={{ whiteSpace: 'pre-wrap', display: 'block' }}
+      tabIndex={0}
+      onClick={() => startEdit(field, value)}
+      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
+    >
+      {value || <span style={{ color: 'var(--text3)' }}>—</span>}
+    </span>
+  )
+}
+
+function InlineSelect({ field, value, options, placeholder = '', editCtx }) {
+  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
+  if (editingField === field) {
+    return (
+      <select
+        className="inline-input"
+        value={draftValue}
+        autoFocus
+        onChange={e => setDraftValue(e.target.value)}
+        onBlur={() => commitEdit(field, draftValue)}
+        onKeyDown={e => e.key === 'Escape' && cancelEdit()}
+      >
+        {placeholder && <option value="">{placeholder}</option>}
+        {options.map(o => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+    )
+  }
+  const found = options.find(o => o.value === value)
+  return (
+    <span
+      className="inline-val"
+      tabIndex={0}
+      onClick={() => startEdit(field, value)}
+      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
+    >
+      {found ? found.label : (value || <span style={{ color: 'var(--text3)' }}>—</span>)}
+    </span>
+  )
+}
+
+export default function MedDetailModal({ med, careTeam = [], onClose }) {
+  const isMobile = useIsMobile()
+  const [editingField, setEditingField] = useState(null)
+  const [draftValue, setDraftValue] = useState('')
+  const [saveStatus, setSaveStatus] = useState('idle')
+  const [confirming, setConfirming] = useState(false)
+  const [refillOpen, setRefillOpen] = useState(false)
+  const saveTimer = useRef(null)
+  const savedTimer = useRef(null)
+  const pendingData = useRef(null)
+
+  useEffect(() => {
+    function onKey(e) { if (e.key === 'Escape' && !editingField) onClose() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose, editingField])
+
+  const m = med
+  const isInactive = m.active === false
+  const rs = m.refillStatus || null
+  const rdDate = getRefillDate(m)
+  const rd = rdDate ? fmtDate(rdDate) : '—'
+
+  function startEdit(field, currentValue) {
+    setEditingField(field)
+    setDraftValue(currentValue ?? '')
+  }
+  function cancelEdit() { setEditingField(null) }
+
+  async function commitEdit(field, value) {
+    setEditingField(null)
+    const base = pendingData.current ?? m
+    if (String(value) === String(base[field] ?? '')) return
+    const updated = { ...base, [field]: value }
+    pendingData.current = updated
+    setSaveStatus('saving')
+    clearTimeout(saveTimer.current)
+    saveTimer.current = setTimeout(async () => {
+      try {
+        await saveMed(pendingData.current, m.id)
+        pendingData.current = null
+        setSaveStatus('saved')
+        clearTimeout(savedTimer.current)
+        savedTimer.current = setTimeout(() => setSaveStatus('idle'), 2500)
+      } catch {
+        setSaveStatus('error')
+      }
+    }, 600)
+  }
+
+  async function handleRefillStatus(status) {
+    try { await updateRefillStatus(m, status) } catch { alert('Failed to update. Check your connection.') }
+  }
+
+  async function handleDeactivate() {
+    if (!confirming) { setConfirming(true); return }
+    try {
+      await deactivateMed(m.id)
+      onClose()
+    } catch { alert('Failed to deactivate. Check your connection.') }
+  }
+
+  async function handleReactivate() {
+    try {
+      await reactivateMed(m.id)
+      onClose()
+    } catch { alert('Failed to reactivate. Check your connection.') }
+  }
+
+  const editCtx = { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit }
+
+  const doctorOptions = [
+    { value: '', label: 'No doctor' },
+    ...careTeam.map(dr => ({ value: dr.name, label: dr.name + (dr.specialty ? ` · ${dr.specialty}` : '') }))
+  ]
+
+  const formContent = (
+    <>
+      <div className="med-drawer-actions">
+        {saveStatus !== 'idle' && (
+          <span className={`autosave-pill ${saveStatus}`} style={{ marginRight: 'auto' }}>
+            <span className="autosave-pill-dot" />
+            {saveStatus === 'saving' && 'Saving…'}
+            {saveStatus === 'saved'  && 'Saved'}
+            {saveStatus === 'error'  && 'Error'}
+          </span>
+        )}
+        {isInactive
+          ? <button className="btn-sv" onClick={handleReactivate}>Reactivate</button>
+          : <>
+              {!rs && (
+                <button className="btn-sv" onClick={() => handleRefillStatus('requested')}>Place request</button>
+              )}
+              {rs === 'requested' && <>
+                <button className="btn-sv" onClick={() => handleRefillStatus('ready-pickup')}>Ready for pickup</button>
+                <button className="btn-sv" onClick={() => handleRefillStatus('ready-courier')}>Ready for courier</button>
+              </>}
+              {rs === 'ready-pickup' && (
+                <button className="btn-sv" onClick={() => handleRefillStatus('picked-up')}>Picked up</button>
+              )}
+              {rs === 'ready-courier' && (
+                <button className="btn-sv" onClick={() => handleRefillStatus('delivered')}>Delivered</button>
+              )}
+              {(rs === 'picked-up' || rs === 'delivered') && (
+                <button className="btn-sv" onClick={() => setRefillOpen(true)}>Mark refilled</button>
+              )}
+              <button
+                className={`btn-cx drawer-deactivate${confirming ? ' danger' : ''}`}
+                onClick={handleDeactivate}
+              >
+                {confirming ? 'Confirm?' : 'Deactivate'}
+              </button>
+            </>
+        }
+      </div>
+
+      <div className="med-drawer-details">
+        <div className="med-drawer-item" style={{ gridColumn: '1 / -1' }}>
+          <span className="med-drawer-lbl">Name</span>
+          <InlineField field="name" value={m.name} placeholder="e.g. Metformin" editCtx={editCtx} />
+        </div>
+
+        <div className="med-drawer-item">
+          <span className="med-drawer-lbl">Dose / strength</span>
+          <InlineField field="dose" value={m.dose} placeholder="e.g. 500 mg" editCtx={editCtx} />
+        </div>
+        <div className="med-drawer-item">
+          <span className="med-drawer-lbl">Frequency</span>
+          <InlineSelect
+            field="frequencyPreset"
+            value={m.frequencyPreset || 'once-daily'}
+            options={PRESETS}
+            editCtx={editCtx}
+          />
+        </div>
+
+        {(pendingData.current ?? m).frequencyPreset === 'custom' && <>
+          <div className="med-drawer-item">
+            <span className="med-drawer-lbl">Pills / dose</span>
+            <InlineField field="frequencyCustomCount" value={m.frequencyCustomCount} type="number" placeholder="1" editCtx={editCtx} />
+          </div>
+          <div className="med-drawer-item">
+            <span className="med-drawer-lbl">Every (days)</span>
+            <InlineField field="frequencyCustomEvery" value={m.frequencyCustomEvery} type="number" placeholder="1" editCtx={editCtx} />
+          </div>
+        </>}
+
+        <div className="med-drawer-item">
+          <span className="med-drawer-lbl">Last filled</span>
+          <InlineField field="filledDate" value={m.filledDate} type="date" editCtx={editCtx} />
+        </div>
+        <div className="med-drawer-item">
+          <span className="med-drawer-lbl">Pills in bottle</span>
+          <InlineField field="supply" value={m.supply} type="number" placeholder="e.g. 30" editCtx={editCtx} />
+        </div>
+
+        <div className="med-drawer-item">
+          <span className="med-drawer-lbl">Runs out</span>
+          <span style={{ color: 'var(--text2)' }}>{rd}</span>
+        </div>
+        <div className="med-drawer-item">
+          <span className="med-drawer-lbl">Pharmacy</span>
+          <InlineField field="pharmacy" value={m.pharmacy} placeholder="e.g. Walgreens" editCtx={editCtx} />
+        </div>
+
+        <div className="med-drawer-item">
+          <span className="med-drawer-lbl">Rx #</span>
+          <InlineField field="rxNum" value={m.rxNum} placeholder="optional" editCtx={editCtx} />
+        </div>
+        <div className="med-drawer-item">
+          <span className="med-drawer-lbl">Doctor</span>
+          <InlineSelect field="doctor" value={m.doctor} options={doctorOptions} editCtx={editCtx} />
+        </div>
+
+        <div className="med-drawer-item" style={{ gridColumn: '1 / -1' }}>
+          <span className="med-drawer-lbl">Instructions</span>
+          <InlineTextarea field="instructions" value={m.instructions} placeholder="e.g. Take with food" editCtx={editCtx} />
+        </div>
+      </div>
+    </>
+  )
+
+  const header = (
+    <span className="sheet-title" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <PersonChip person={m.person} />
+      {m.name}
+    </span>
+  )
+
+  if (!isMobile) {
+    return (
+      <div className="modal-bg" onClick={e => { if (e.target === e.currentTarget && !editingField) onClose() }}>
+        <div className="modal" role="dialog" aria-modal="true">
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+            {header}
+            <button className="note-close-btn" onClick={onClose} aria-label="Close">✕</button>
+          </div>
+          {formContent}
+        </div>
+        {refillOpen && <RefillModal med={m} onClose={() => setRefillOpen(false)} />}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="fs-overlay" role="dialog" aria-modal="true">
+        <div className="fs-header">
+          {header}
+          <button className="note-close-btn" onClick={onClose} aria-label="Close">✕</button>
+        </div>
+        <div className="fs-body">{formContent}</div>
+      </div>
+      {refillOpen && <RefillModal med={m} onClose={() => setRefillOpen(false)} />}
+    </>
+  )
+}

--- a/client/src/components/meds/MedGroupSection.jsx
+++ b/client/src/components/meds/MedGroupSection.jsx
@@ -9,22 +9,16 @@ const GROUP_META = {
   ok:     { label: 'Stocked up',       variant: 'ok',     defaultOpen: false },
 }
 
-export default function MedGroupSection({ groupKey, meds, sectionRef, careTeam = [] }) {
+export default function MedGroupSection({ groupKey, meds, sectionRef, onOpen }) {
   const meta = GROUP_META[groupKey]
   const [isOpen, setIsOpen] = useState(meta.defaultOpen)
-  const [expandedId, setExpandedId] = useState(null)
 
   if (!meds.length) return null
-
-  function toggleRow(id) {
-    setExpandedId(prev => prev === id ? null : id)
-  }
 
   const isStocked = groupKey === 'ok'
 
   return (
     <div className={`med-group med-group-${meta.variant}`} ref={sectionRef}>
-      {/* Header only shown when group is expanded (stocked) or always (urgent/soon) */}
       {(!isStocked || isOpen) && (
         <MedGroupHeader
           label={meta.label}
@@ -37,13 +31,7 @@ export default function MedGroupSection({ groupKey, meds, sectionRef, careTeam =
       <div className="med-group-body">
         {isOpen
           ? meds.map(m => (
-              <MedRow
-                key={m.id}
-                m={m}
-                careTeam={careTeam}
-                isExpanded={expandedId === m.id}
-                onToggleExpand={() => toggleRow(m.id)}
-              />
+              <MedRow key={m.id} m={m} onOpen={() => onOpen(m.id)} />
             ))
           : (
               <MedStockedCollapsed

--- a/client/src/components/meds/MedRow.jsx
+++ b/client/src/components/meds/MedRow.jsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect } from 'react'
 import { pillsNow, supplyStatus, supplyStatusLabel, refillStatusLabel, pillStatusClass, fmtDate, freqLabel, getRefillDate } from '../../lib/medUtils'
-import { saveMed, markRefilled, updateRefillStatus, deactivateMed, reactivateMed } from '../../lib/firestore'
+import { saveMed, updateRefillStatus, deactivateMed, reactivateMed } from '../../lib/firestore'
 import PersonChip from '../PersonChip'
+import RefillModal from './RefillModal'
 
 const PRESETS = [
   { value: 'once-daily',      label: 'Once daily' },
@@ -110,6 +111,7 @@ function InlineSelect({ field, value, options, placeholder = '', editCtx }) {
 export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand }) {
   const [menuOpen, setMenuOpen] = useState(false)
   const [confirming, setConfirming] = useState(false)
+  const [refillOpen, setRefillOpen] = useState(false)
   const menuRef = useRef()
 
   // Inline edit state
@@ -144,10 +146,10 @@ export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand })
     return () => document.removeEventListener('mousedown', onOutsideClick)
   }, [menuOpen])
 
-  async function handleRefill(e) {
+  function handleRefill(e) {
     e.stopPropagation()
-    try { await markRefilled(m) } catch { alert('Failed to update. Check your connection.') }
     setMenuOpen(false)
+    setRefillOpen(true)
   }
 
   async function handleRefillStatus(e, status) {
@@ -419,6 +421,8 @@ export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand })
           </div>
         </div>
       </div>
+
+      {refillOpen && <RefillModal med={m} onClose={() => setRefillOpen(false)} />}
     </div>
   )
 }

--- a/client/src/components/meds/MedRow.jsx
+++ b/client/src/components/meds/MedRow.jsx
@@ -1,127 +1,7 @@
-import { useState, useRef, useEffect } from 'react'
 import { pillsNow, supplyStatus, supplyStatusLabel, refillStatusLabel, pillStatusClass, fmtDate, freqLabel, getRefillDate } from '../../lib/medUtils'
-import { saveMed, updateRefillStatus, deactivateMed, reactivateMed } from '../../lib/firestore'
 import PersonChip from '../PersonChip'
-import RefillModal from './RefillModal'
 
-const PRESETS = [
-  { value: 'once-daily',      label: 'Once daily' },
-  { value: 'twice-daily',     label: 'Twice daily' },
-  { value: 'every-other-day', label: 'Every other day' },
-  { value: 'as-needed',       label: 'As needed' },
-  { value: 'custom',          label: 'Custom…' },
-]
-
-function InlineField({ field, value, type = 'text', placeholder = '', editCtx }) {
-  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
-  if (editingField === field) {
-    return (
-      <input
-        className="inline-input"
-        type={type}
-        value={draftValue}
-        autoFocus
-        onChange={e => setDraftValue(e.target.value)}
-        onBlur={() => commitEdit(field, draftValue)}
-        onKeyDown={e => {
-          if (e.key === 'Enter') commitEdit(field, draftValue)
-          if (e.key === 'Escape') cancelEdit()
-        }}
-        placeholder={placeholder}
-        onClick={e => e.stopPropagation()}
-      />
-    )
-  }
-  const display = type === 'date' && value ? fmtDate(value) : value
-  return (
-    <span
-      className="inline-val"
-      tabIndex={0}
-      onClick={e => { e.stopPropagation(); startEdit(field, value) }}
-      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
-    >
-      {display || <span style={{ color: 'var(--text3)' }}>—</span>}
-    </span>
-  )
-}
-
-function InlineTextarea({ field, value, placeholder = '', editCtx }) {
-  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
-  if (editingField === field) {
-    return (
-      <textarea
-        className="inline-input"
-        rows={3}
-        value={draftValue}
-        autoFocus
-        onChange={e => setDraftValue(e.target.value)}
-        onBlur={() => commitEdit(field, draftValue)}
-        onKeyDown={e => e.key === 'Escape' && cancelEdit()}
-        placeholder={placeholder}
-        onClick={e => e.stopPropagation()}
-      />
-    )
-  }
-  return (
-    <span
-      className="inline-val"
-      style={{ whiteSpace: 'pre-wrap', display: 'block' }}
-      tabIndex={0}
-      onClick={e => { e.stopPropagation(); startEdit(field, value) }}
-      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
-    >
-      {value || <span style={{ color: 'var(--text3)' }}>—</span>}
-    </span>
-  )
-}
-
-function InlineSelect({ field, value, options, placeholder = '', editCtx }) {
-  const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
-  if (editingField === field) {
-    return (
-      <select
-        className="inline-input"
-        value={draftValue}
-        autoFocus
-        onChange={e => setDraftValue(e.target.value)}
-        onBlur={() => commitEdit(field, draftValue)}
-        onKeyDown={e => e.key === 'Escape' && cancelEdit()}
-        onClick={e => e.stopPropagation()}
-      >
-        {placeholder && <option value="">{placeholder}</option>}
-        {options.map(o => (
-          <option key={o.value} value={o.value}>{o.label}</option>
-        ))}
-      </select>
-    )
-  }
-  const found = options.find(o => o.value === value)
-  return (
-    <span
-      className="inline-val"
-      tabIndex={0}
-      onClick={e => { e.stopPropagation(); startEdit(field, value) }}
-      onKeyDown={e => e.key === 'Enter' && startEdit(field, value)}
-    >
-      {found ? found.label : (value || <span style={{ color: 'var(--text3)' }}>—</span>)}
-    </span>
-  )
-}
-
-export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand }) {
-  const [menuOpen, setMenuOpen] = useState(false)
-  const [confirming, setConfirming] = useState(false)
-  const [refillOpen, setRefillOpen] = useState(false)
-  const menuRef = useRef()
-
-  // Inline edit state
-  const [editingField, setEditingField] = useState(null)
-  const [draftValue, setDraftValue] = useState('')
-  const [saveStatus, setSaveStatus] = useState('idle')
-  const saveTimer   = useRef(null)
-  const savedTimer  = useRef(null)
-  const pendingData = useRef(null)
-
+export default function MedRow({ m, onOpen }) {
   const isInactive = m.active === false
   const s = supplyStatus(m)
   const lbl = supplyStatusLabel(m)
@@ -135,85 +15,15 @@ export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand })
   const sub = [m.dose, m.rxNum ? 'Rx ' + m.rxNum : '', fl].filter(Boolean).join(' · ')
   const rdDate = getRefillDate(m)
   const rd = rdDate ? fmtDate(rdDate) : '—'
-  const rs = m.refillStatus || null
-
-  useEffect(() => {
-    if (!menuOpen) { setConfirming(false); return }
-    function onOutsideClick(e) {
-      if (menuRef.current && !menuRef.current.contains(e.target)) setMenuOpen(false)
-    }
-    document.addEventListener('mousedown', onOutsideClick)
-    return () => document.removeEventListener('mousedown', onOutsideClick)
-  }, [menuOpen])
-
-  function handleRefill(e) {
-    e.stopPropagation()
-    setMenuOpen(false)
-    setRefillOpen(true)
-  }
-
-  async function handleRefillStatus(e, status) {
-    e.stopPropagation()
-    try { await updateRefillStatus(m, status) } catch { alert('Failed to update. Check your connection.') }
-    setMenuOpen(false)
-  }
-
-  async function handleDeactivate(e) {
-    e.stopPropagation()
-    if (!confirming) { setConfirming(true); return }
-    setMenuOpen(false)
-    try { await deactivateMed(m.id) } catch { alert('Failed to deactivate. Check your connection.') }
-  }
-
-  async function handleReactivate(e) {
-    e.stopPropagation()
-    setMenuOpen(false)
-    try { await reactivateMed(m.id) } catch { alert('Failed to reactivate. Check your connection.') }
-  }
-
-  // ── Inline edit helpers ────────────────────────────────────────────────────
-
-  function startEdit(field, currentValue) {
-    setEditingField(field)
-    setDraftValue(currentValue ?? '')
-  }
-
-  function cancelEdit() { setEditingField(null) }
-
-  async function commitEdit(field, value) {
-    setEditingField(null)
-    const base = pendingData.current ?? m
-    if (String(value) === String(base[field] ?? '')) return
-    const updated = { ...base, [field]: value }
-    pendingData.current = updated
-    setSaveStatus('saving')
-    clearTimeout(saveTimer.current)
-    saveTimer.current = setTimeout(async () => {
-      try {
-        await saveMed(pendingData.current, m.id)
-        pendingData.current = null
-        setSaveStatus('saved')
-        clearTimeout(savedTimer.current)
-        savedTimer.current = setTimeout(() => setSaveStatus('idle'), 2500)
-      } catch {
-        setSaveStatus('error')
-      }
-    }, 600)
-  }
-
-  const editCtx = { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit }
-
-  const doctorOptions = [
-    { value: '', label: 'No doctor' },
-    ...careTeam.map(dr => ({ value: dr.name, label: dr.name + (dr.specialty ? ` · ${dr.specialty}` : '') }))
-  ]
 
   return (
-    <div className={`med-row${isExpanded ? ' row-open' : ''}${isInactive ? ' med-row-inactive' : ''}`} style={{ borderLeft: `3px solid var(--${m.person || 'dad'})` }}>
-      {/* ── Main row ── */}
-      <div className="med-row-main" onClick={onToggleExpand}>
+    <div
+      className={`med-row${isInactive ? ' med-row-inactive' : ''}`}
+      style={{ borderLeft: `3px solid var(--${m.person || 'dad'})`, cursor: 'pointer' }}
+      onClick={onOpen}
+    >
+      <div className="med-row-main">
 
-        {/* Col 1: Name + subtitle */}
         <div className="med-col-name">
           <div className="med-name" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
             <PersonChip person={m.person} />
@@ -225,7 +35,6 @@ export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand })
           </div>
         </div>
 
-        {/* Col 2: Days remaining + bar  (hidden on mobile) */}
         <div className="med-col-pills">
           <div className="pills-top">
             <span className={`pill-count ${pc}`}>
@@ -241,7 +50,6 @@ export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand })
           </div>
         </div>
 
-        {/* Col 3: Status pill + optional refill badge  (on mobile also contains mini pills) */}
         <div className="med-col-status">
           <span className={`spill sp-${pillSt}`}>{lbl}</span>
           {rsl && <span className="refill-status-badge">{rsl}</span>}
@@ -256,173 +64,9 @@ export default function MedRow({ m, careTeam = [], isExpanded, onToggleExpand })
           </div>
         </div>
 
-        {/* Col 4: Refill date  (hidden on tablet + mobile) */}
         <div className="med-col-date">{rd}</div>
-
-        {/* Col 5: Pharmacy  (hidden on tablet + mobile) */}
         <div className="med-col-pharm">{m.pharmacy || '—'}</div>
-
-        {/* Col 6: ⋯ menu  (hidden on mobile — actions live in drawer) */}
-        <div className="med-col-menu" ref={menuRef} onClick={e => e.stopPropagation()}>
-          <button
-            className="med-menu-btn"
-            onClick={() => { setMenuOpen(o => !o); setConfirming(false) }}
-            title="Options"
-          >
-            ···
-          </button>
-          {menuOpen && (
-            <div className="med-menu-pop">
-              {!isInactive && !rs && (
-                <button className="med-menu-item" onClick={e => handleRefillStatus(e, 'requested')}>Place request</button>
-              )}
-              {!isInactive && rs === 'requested' && <>
-                <button className="med-menu-item" onClick={e => handleRefillStatus(e, 'ready-pickup')}>Ready for pickup</button>
-                <button className="med-menu-item" onClick={e => handleRefillStatus(e, 'ready-courier')}>Ready for courier</button>
-              </>}
-              {!isInactive && rs === 'ready-pickup' && (
-                <button className="med-menu-item" onClick={e => handleRefillStatus(e, 'picked-up')}>Picked up</button>
-              )}
-              {!isInactive && rs === 'ready-courier' && (
-                <button className="med-menu-item" onClick={e => handleRefillStatus(e, 'delivered')}>Delivered</button>
-              )}
-              {!isInactive && (rs === 'picked-up' || rs === 'delivered') && (
-                <button className="med-menu-item" onClick={handleRefill}>Mark refilled</button>
-              )}
-              {isInactive
-                ? <button className="med-menu-item" onClick={handleReactivate}>Reactivate</button>
-                : <button
-                    className={`med-menu-item${confirming ? ' danger confirm' : ' danger'}`}
-                    onClick={handleDeactivate}
-                  >
-                    {confirming ? 'Confirm deactivate?' : 'Deactivate'}
-                  </button>
-              }
-            </div>
-          )}
-        </div>
       </div>
-
-      {/* ── Inline drawer — all fields, inline editable ── */}
-      <div className={`med-drawer${isExpanded ? ' open' : ''}`}>
-        <div className="med-drawer-inner">
-
-          {/* Refill workflow actions */}
-          <div className="med-drawer-actions">
-            {saveStatus !== 'idle' && (
-              <span className={`autosave-pill ${saveStatus}`} style={{ marginRight: 'auto' }}>
-                <span className="autosave-pill-dot" />
-                {saveStatus === 'saving' && 'Saving…'}
-                {saveStatus === 'saved'  && 'Saved'}
-                {saveStatus === 'error'  && 'Error'}
-              </span>
-            )}
-            {isInactive
-              ? <button className="btn-sv" onClick={handleReactivate}>Reactivate</button>
-              : <>
-                  {!rs && (
-                    <button className="btn-sv" onClick={e => handleRefillStatus(e, 'requested')}>Place request</button>
-                  )}
-                  {rs === 'requested' && <>
-                    <button className="btn-sv" onClick={e => handleRefillStatus(e, 'ready-pickup')}>Ready for pickup</button>
-                    <button className="btn-sv" onClick={e => handleRefillStatus(e, 'ready-courier')}>Ready for courier</button>
-                  </>}
-                  {rs === 'ready-pickup' && (
-                    <button className="btn-sv" onClick={e => handleRefillStatus(e, 'picked-up')}>Picked up</button>
-                  )}
-                  {rs === 'ready-courier' && (
-                    <button className="btn-sv" onClick={e => handleRefillStatus(e, 'delivered')}>Delivered</button>
-                  )}
-                  {(rs === 'picked-up' || rs === 'delivered') && (
-                    <button className="btn-sv" onClick={handleRefill}>Mark refilled</button>
-                  )}
-                  <button
-                    className={`btn-cx drawer-deactivate${confirming ? ' danger' : ''}`}
-                    onClick={handleDeactivate}
-                  >
-                    {confirming ? 'Confirm?' : 'Deactivate'}
-                  </button>
-                </>
-            }
-          </div>
-
-          {/* All fields — inline editable */}
-          <div className="med-drawer-details">
-
-            {/* Name — full width */}
-            <div className="med-drawer-item" style={{ gridColumn: '1 / -1' }}>
-              <span className="med-drawer-lbl">Name</span>
-              <InlineField field="name" value={m.name} placeholder="e.g. Metformin" editCtx={editCtx} />
-            </div>
-
-            {/* Dose + Frequency */}
-            <div className="med-drawer-item">
-              <span className="med-drawer-lbl">Dose / strength</span>
-              <InlineField field="dose" value={m.dose} placeholder="e.g. 500 mg" editCtx={editCtx} />
-            </div>
-            <div className="med-drawer-item">
-              <span className="med-drawer-lbl">Frequency</span>
-              <InlineSelect
-                field="frequencyPreset"
-                value={m.frequencyPreset || 'once-daily'}
-                options={PRESETS}
-                editCtx={editCtx}
-              />
-            </div>
-
-            {/* Custom frequency sub-fields */}
-            {(pendingData.current ?? m).frequencyPreset === 'custom' && <>
-              <div className="med-drawer-item">
-                <span className="med-drawer-lbl">Pills / dose</span>
-                <InlineField field="frequencyCustomCount" value={m.frequencyCustomCount} type="number" placeholder="1" editCtx={editCtx} />
-              </div>
-              <div className="med-drawer-item">
-                <span className="med-drawer-lbl">Every (days)</span>
-                <InlineField field="frequencyCustomEvery" value={m.frequencyCustomEvery} type="number" placeholder="1" editCtx={editCtx} />
-              </div>
-            </>}
-
-            {/* Last filled + Supply */}
-            <div className="med-drawer-item">
-              <span className="med-drawer-lbl">Last filled</span>
-              <InlineField field="filledDate" value={m.filledDate} type="date" editCtx={editCtx} />
-            </div>
-            <div className="med-drawer-item">
-              <span className="med-drawer-lbl">Pills in bottle</span>
-              <InlineField field="supply" value={m.supply} type="number" placeholder="e.g. 30" editCtx={editCtx} />
-            </div>
-
-            {/* Run-out date (calculated) + Pharmacy */}
-            <div className="med-drawer-item">
-              <span className="med-drawer-lbl">Runs out</span>
-              <span style={{ color: 'var(--text2)' }}>{rd}</span>
-            </div>
-            <div className="med-drawer-item">
-              <span className="med-drawer-lbl">Pharmacy</span>
-              <InlineField field="pharmacy" value={m.pharmacy} placeholder="e.g. Walgreens" editCtx={editCtx} />
-            </div>
-
-            {/* Rx # + Doctor */}
-            <div className="med-drawer-item">
-              <span className="med-drawer-lbl">Rx #</span>
-              <InlineField field="rxNum" value={m.rxNum} placeholder="optional" editCtx={editCtx} />
-            </div>
-            <div className="med-drawer-item">
-              <span className="med-drawer-lbl">Doctor</span>
-              <InlineSelect field="doctor" value={m.doctor} options={doctorOptions} editCtx={editCtx} />
-            </div>
-
-            {/* Instructions — full width */}
-            <div className="med-drawer-item" style={{ gridColumn: '1 / -1' }}>
-              <span className="med-drawer-lbl">Instructions</span>
-              <InlineTextarea field="instructions" value={m.instructions} placeholder="e.g. Take with food" editCtx={editCtx} />
-            </div>
-
-          </div>
-        </div>
-      </div>
-
-      {refillOpen && <RefillModal med={m} onClose={() => setRefillOpen(false)} />}
     </div>
   )
 }

--- a/client/src/components/meds/MedicationsView.jsx
+++ b/client/src/components/meds/MedicationsView.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useMemo } from 'react'
 import MedGroupSection from './MedGroupSection'
 import MedRow from './MedRow'
 import MedModal from './MedModal'
+import MedDetailModal from './MedDetailModal'
 import MedGroupHeader from './MedGroupHeader'
 import { exportCSV, exportJSON, importMeds } from '../../lib/firestore'
 import { supplyStatus, pillsNow } from '../../lib/medUtils'
@@ -24,7 +25,7 @@ export default function MedicationsView({ meds, careTeam, personFilter, onPerson
   const [search, setSearch] = useState('')
   const [addOpen, setAddOpen] = useState(false)
   const [showInactive, setShowInactive] = useState(false)
-  const [expandedInactiveId, setExpandedInactiveId] = useState(null)
+  const [viewingMedId, setViewingMedId] = useState(null)
   const fileRef = useRef()
 
   const urgentRef = useRef()
@@ -94,9 +95,9 @@ export default function MedicationsView({ meds, careTeam, personFilter, onPerson
       ) : (
         <div className="med-groups">
           {filtered.length > 0 && <>
-            <MedGroupSection groupKey="urgent" meds={grouped.urgent} sectionRef={urgentRef} careTeam={careTeam} />
-            <MedGroupSection groupKey="soon"   meds={grouped.soon}   sectionRef={soonRef}   careTeam={careTeam} />
-            <MedGroupSection groupKey="ok"     meds={grouped.ok}     sectionRef={okRef}     careTeam={careTeam} />
+            <MedGroupSection groupKey="urgent" meds={grouped.urgent} sectionRef={urgentRef} onOpen={setViewingMedId} />
+            <MedGroupSection groupKey="soon"   meds={grouped.soon}   sectionRef={soonRef}   onOpen={setViewingMedId} />
+            <MedGroupSection groupKey="ok"     meds={grouped.ok}     sectionRef={okRef}     onOpen={setViewingMedId} />
           </>}
           {inactiveMeds.length > 0 && (
             <div className="med-group med-group-inactive">
@@ -110,13 +111,7 @@ export default function MedicationsView({ meds, careTeam, personFilter, onPerson
               {showInactive && (
                 <div className="med-group-body">
                   {inactiveMeds.map(m => (
-                    <MedRow
-                      key={m.id}
-                      m={m}
-                      careTeam={careTeam}
-                      isExpanded={expandedInactiveId === m.id}
-                      onToggleExpand={() => setExpandedInactiveId(prev => prev === m.id ? null : m.id)}
-                    />
+                    <MedRow key={m.id} m={m} onOpen={() => setViewingMedId(m.id)} />
                   ))}
                 </div>
               )}
@@ -128,6 +123,12 @@ export default function MedicationsView({ meds, careTeam, personFilter, onPerson
       {addOpen && (
         <MedModal careTeam={careTeam} onClose={() => setAddOpen(false)} />
       )}
+
+      {viewingMedId && (() => {
+        const med = meds.find(x => x.id === viewingMedId)
+        if (!med) return null
+        return <MedDetailModal med={med} careTeam={careTeam} onClose={() => setViewingMedId(null)} />
+      })()}
     </div>
   )
 }

--- a/client/src/components/meds/MedsTable.jsx
+++ b/client/src/components/meds/MedsTable.jsx
@@ -1,7 +1,10 @@
+import { useState } from 'react'
 import { pillsNow, supplyStatus, supplyStatusLabel, pillStatusClass, fmtDate, getRefillDate, freqLabel } from '../../lib/medUtils'
-import { markRefilled, delMed } from '../../lib/firestore'
+import { delMed } from '../../lib/firestore'
+import RefillModal from './RefillModal'
 
 export default function MedsTable({ meds, filter, search, onEdit }) {
+  const [refillMed, setRefillMed] = useState(null)
   const q = search.toLowerCase()
 
   let rows = [...meds].sort((a, b) => pillsNow(a).daysToZero - pillsNow(b).daysToZero)
@@ -15,10 +18,6 @@ export default function MedsTable({ meds, filter, search, onEdit }) {
   async function handleDelete(m) {
     if (!confirm(`Remove ${m.name}?`)) return
     try { await delMed(m.id) } catch { alert('Failed to delete. Check your connection.') }
-  }
-
-  async function handleRefill(m) {
-    try { await markRefilled(m) } catch { alert('Failed to update. Check your connection.') }
   }
 
   if (!rows.length) {
@@ -100,7 +99,7 @@ export default function MedsTable({ meds, filter, search, onEdit }) {
                 <td className="td-dt">{rd}</td>
                 <td className="td-ph">{m.pharmacy || '—'}</td>
                 <td className="td-act">
-                  <button className="act green" title="Mark refilled" onClick={e => { e.stopPropagation(); handleRefill(m) }}>✓</button>
+                  <button className="act green" title="Mark refilled" onClick={e => { e.stopPropagation(); setRefillMed(m) }}>✓</button>
                   <button className="act red" title="Remove" onClick={e => { e.stopPropagation(); handleDelete(m) }}>✕</button>
                 </td>
               </tr>
@@ -108,6 +107,7 @@ export default function MedsTable({ meds, filter, search, onEdit }) {
           })}
         </tbody>
       </table>
+      {refillMed && <RefillModal med={refillMed} onClose={() => setRefillMed(null)} />}
     </div>
   )
 }

--- a/client/src/components/meds/RefillModal.jsx
+++ b/client/src/components/meds/RefillModal.jsx
@@ -1,0 +1,136 @@
+import { useState, useEffect } from 'react'
+import { markRefilled } from '../../lib/firestore'
+import { useIsMobile } from '../../hooks/useIsMobile'
+import { todayStr, freqPerDay, fmtDate } from '../../lib/medUtils'
+
+const PRESETS = [
+  { value: 'once-daily',      label: 'Once daily' },
+  { value: 'twice-daily',     label: 'Twice daily' },
+  { value: 'every-other-day', label: 'Every other day' },
+  { value: 'as-needed',       label: 'As needed' },
+  { value: 'custom',          label: 'Custom…' },
+]
+
+export default function RefillModal({ med, onClose }) {
+  const isMobile = useIsMobile()
+  const [form, setForm] = useState({
+    filledDate: todayStr(),
+    supply: String(med.supply ?? ''),
+    dose: med.dose || '',
+    frequencyPreset: med.frequencyPreset || 'once-daily',
+    frequencyCustomCount: med.frequencyCustomCount || '1',
+    frequencyCustomEvery: med.frequencyCustomEvery || '1',
+    frequencyCustomUnit: med.frequencyCustomUnit || 'days',
+  })
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    function onKey(e) { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  function set(field) {
+    return e => setForm(f => ({ ...f, [field]: e.target.value }))
+  }
+
+  async function handleConfirm() {
+    if (!form.filledDate) { alert('Please enter the fill date.'); return }
+    if (!form.supply)     { alert('Please enter how many pills are in the bottle.'); return }
+    setSaving(true)
+    try {
+      await markRefilled(med, form)
+      onClose()
+    } catch { alert('Failed to save. Check your connection.') }
+    setSaving(false)
+  }
+
+  const formContent = (
+    <>
+      <div className="fr">
+        <label>Fill date <span className="req">*</span></label>
+        <input type="date" value={form.filledDate} onChange={set('filledDate')} />
+      </div>
+      <div className="f2">
+        <div className="fr">
+          <label>Pills in bottle <span className="req">*</span></label>
+          <input type="number" min="1" value={form.supply} onChange={set('supply')} placeholder="e.g. 30" />
+        </div>
+        <div className="fr">
+          <label>Dose / strength</label>
+          <input value={form.dose} onChange={set('dose')} placeholder="e.g. 500 mg" />
+        </div>
+      </div>
+      <div className="fr">
+        <label>Frequency <span className="req">*</span></label>
+        <select value={form.frequencyPreset} onChange={set('frequencyPreset')}>
+          {PRESETS.map(p => <option key={p.value} value={p.value}>{p.label}</option>)}
+        </select>
+      </div>
+      {form.frequencyPreset === 'custom' && (
+        <div className="f2">
+          <div className="fr">
+            <label>Pills per dose</label>
+            <input type="number" min="0.5" step="0.5" value={form.frequencyCustomCount} onChange={set('frequencyCustomCount')} placeholder="1" />
+          </div>
+          <div className="fr">
+            <label>Every</label>
+            <div style={{ display: 'flex', gap: '6px' }}>
+              <input type="number" min="1" step="1" value={form.frequencyCustomEvery} onChange={set('frequencyCustomEvery')} placeholder="1" style={{ flex: 1 }} />
+              <select value={form.frequencyCustomUnit} onChange={set('frequencyCustomUnit')} style={{ flex: 1 }}>
+                <option value="days">days</option>
+                <option value="weeks">weeks</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {form.filledDate && form.supply && form.frequencyPreset !== 'as-needed' && (() => {
+        const freq = freqPerDay(form)
+        const days = freq > 0 ? Math.ceil(parseInt(form.supply) / freq) : null
+        if (!days) return null
+        const d = new Date(form.filledDate + 'T00:00:00')
+        d.setDate(d.getDate() + days)
+        return (
+          <div className="fr-hint" style={{ marginBottom: 4 }}>
+            Runs out approx. {fmtDate(d)}
+          </div>
+        )
+      })()}
+
+      <div className="mf">
+        <button className="btn-cx" onClick={onClose}>Cancel</button>
+        <button className="btn-sv" onClick={handleConfirm} disabled={saving}>
+          {saving ? 'Saving…' : 'Confirm refill'}
+        </button>
+      </div>
+    </>
+  )
+
+  const title = `Refill ${med.name}`
+
+  if (!isMobile) {
+    return (
+      <div className="modal-bg" onClick={e => { if (e.target === e.currentTarget) onClose() }}>
+        <div className="modal" role="dialog" aria-modal="true">
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+            <span className="sheet-title">{title}</span>
+            <button className="note-close-btn" onClick={onClose} aria-label="Close">✕</button>
+          </div>
+          {formContent}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="fs-overlay" role="dialog" aria-modal="true">
+      <div className="fs-header">
+        <span className="fs-title">{title}</span>
+        <button className="note-close-btn" onClick={onClose} aria-label="Close">✕</button>
+      </div>
+      <div className="fs-body">{formContent}</div>
+    </div>
+  )
+}

--- a/client/src/lib/firestore.js
+++ b/client/src/lib/firestore.js
@@ -60,10 +60,20 @@ export async function reactivateMed(id) {
   await updateDoc(doc(db, 'medications', id), { active: true })
 }
 
-export async function markRefilled(med) {
+export async function markRefilled(med, overrides = {}) {
+  const hasFreq = overrides.frequencyPreset !== undefined
   const updated = {
     ...med,
-    filledDate: todayStr(),
+    filledDate: overrides.filledDate || todayStr(),
+    supply: overrides.supply ?? med.supply,
+    dose: overrides.dose ?? med.dose,
+    ...(hasFreq && {
+      frequency: computeFrequency(overrides),
+      frequencyPreset: overrides.frequencyPreset,
+      frequencyCustomCount: overrides.frequencyCustomCount || '1',
+      frequencyCustomEvery: overrides.frequencyCustomEvery || '1',
+      frequencyCustomUnit: overrides.frequencyCustomUnit || 'days',
+    }),
     refillDate: '',
     refillStatus: null,
     updatedAt: new Date().toISOString()


### PR DESCRIPTION
## Summary
- **Refill confirmation modal** — Tapping "Mark refilled" now opens a small modal/sheet with **Fill date** (defaults to today), **Pills in bottle**, **Dose / strength**, and **Frequency**. All fields are prefilled with current values, so the default flow is still effectively one tap (open + confirm). `markRefilled(med, overrides)` recomputes `frequency` via `computeFrequency` if frequency fields are passed.
- **Med detail full-screen modal** — Clicking a med row now opens a modal (full-screen sheet on mobile) instead of expanding an inline drawer beneath the row, matching the task and appointment patterns. The kebab menu is gone — its actions all live in the detail modal now. `MedicationsView` hosts a single modal instance.
- **e2e tests updated** — `medications.spec.js` rewritten against the new modal selectors and the refill confirmation step.

## Test plan
- [x] `npm run test:run` — 62 unit tests pass
- [x] `npm run build` — clean build
- [ ] `npm run test:e2e` — could not execute in the sandbox (Playwright Chromium binary missing); please run locally before merge
- [ ] Smoke: tap a med row, confirm modal opens with all fields editable
- [ ] Smoke: step Mark refilled flow → confirm refill modal opens, defaults populate, Confirm refill clears the workflow badge
- [ ] Smoke: deactivate / reactivate from the modal still works

https://claude.ai/code/session_01VofPirK643JuAvdFiZRd8e

---
_Generated by [Claude Code](https://claude.ai/code/session_01VofPirK643JuAvdFiZRd8e)_