### PR TITLE
Add back button to step refill status backward

### DIFF
--- a/client/src/components/meds/MedDetailModal.jsx
+++ b/client/src/components/meds/MedDetailModal.jsx
@@ -13,6 +13,14 @@ const PRESETS = [
   { value: 'custom',          label: 'Custom…' },
 ]
 
+const PREV_REFILL_STATUS = {
+  'requested':     null,
+  'ready-pickup':  'requested',
+  'ready-courier': 'requested',
+  'picked-up':     'ready-pickup',
+  'delivered':     'ready-courier',
+}
+
 function InlineField({ field, value, type = 'text', placeholder = '', editCtx }) {
   const { editingField, draftValue, setDraftValue, commitEdit, cancelEdit, startEdit } = editCtx
   if (editingField === field) {
@@ -211,6 +219,15 @@ export default function MedDetailModal({ med, careTeam = [], onClose }) {
               )}
               {(rs === 'picked-up' || rs === 'delivered') && (
                 <button className="btn-sv" onClick={() => setRefillOpen(true)}>Mark refilled</button>
+              )}
+              {rs && (
+                <button
+                  className="btn-cx"
+                  onClick={() => handleRefillStatus(PREV_REFILL_STATUS[rs])}
+                  title="Undo last refill status change"
+                >
+                  ← Back
+                </button>
               )}
               <button
                 className={`btn-cx drawer-deactivate${confirming ? ' danger' : ''}`}


### PR DESCRIPTION
If you advance the refill status by mistake (e.g. tap "Ready for
pickup" when it isn't), there's no way to undo it. Add a "← Back"
button in the med detail modal that walks the status one step back:
requested→null, ready-pickup/courier→requested, picked-up→ready-pickup,
delivered→ready-courier.

https://claude.ai/code/session_01UZMhoxVp8JtDcHXoUXYXWp