### PR TITLE
Fill history & future-dated refills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,3 +122,14 @@ FCM token registration (with device metadata) and foreground message handling.
 ### Firebase Config
 
 API keys are in `client/src/firebase.js`. This is intentional for a client-side app — access is controlled by Firestore security rules in the Firebase console, not in this repo.
+
+## Mockups
+
+HTML mockup files live in `.mockup/` at the project root. Serve them locally with:
+
+```bash
+cd .mockup && python3 -m http.server 7777
+# visit http://localhost:7777/<file>.html
+```
+
+Playwright screenshots must be saved to `.playwright-mcp/` — always pass `filename: ".playwright-mcp/<name>.png"` in `browser_take_screenshot` calls.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ client/src/
 │   ├── CareTeamPanel.jsx
 │   ├── NotificationBanner.jsx
 │   ├── PersonChip.jsx
-│   ├── meds/            # MedicationsView, MedsTable, MedModal, KPIRow, MedRow, MedGroupHeader, MedGroupSection, MedStockedCollapsed
+│   ├── meds/            # MedicationsView, MedsTable, MedModal, MedDetailModal, RefillModal, KPIRow, MedRow, MedGroupHeader, MedGroupSection, MedStockedCollapsed
 │   ├── apts/            # AppointmentsView, AptCard, AptModal, AptDetailModal, HeroCard, MiniCalendar, AgendaGroups
 │   ├── tasks/           # TasksView, TaskModal
 │   ├── timeline/        # TimelineView, DiseaseTimelineCard, MilestoneRow, MilestoneTag, PhaseStrip

--- a/client/e2e/medications.spec.js
+++ b/client/e2e/medications.spec.js
@@ -121,7 +121,9 @@ test.describe('medications', () => {
     const refillModal = page.locator('[role="dialog"]', { hasText: `Refill ${name}` });
     await refillModal.waitFor({ timeout: 5_000 });
     await refillModal.getByRole('button', { name: /Confirm refill/ }).click();
-    // After confirming, both modals close and the med moves to the collapsed stocked group
+    // RefillModal closes; close MedDetailModal too, then verify med moved to stocked group
+    await refillModal.waitFor({ state: 'hidden', timeout: 10_000 });
+    await modal.getByRole('button', { name: 'Close' }).click();
     await page.locator('.med-group-ok').waitFor({ timeout: 15_000 });
     await page.locator('.med-group-ok .stk-show-btn').click();
     const stockedRow = page.locator('.med-group-ok .med-row', { hasText: name });
@@ -130,6 +132,57 @@ test.describe('medications', () => {
     await reopened.waitFor({ timeout: 5_000 });
     await expect(reopened.locator('.med-drawer-actions').getByRole('button', { name: 'Place request' })).toBeVisible();
     await expect(stockedRow.locator('.med-row-main')).not.toContainText(/Requested/);
+  });
+
+  test('fill history appears after refill with active entry', async ({ page }) => {
+    const name = `[e2e] FillHist ${Date.now()}`;
+    await addMed(page, name);
+    await page.locator('.med-row-main', { hasText: name }).click();
+    const modal = detailModal(page, name);
+    await modal.waitFor({ timeout: 5_000 });
+    // Step through to mark refilled
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Place request' }).click();
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Ready for pickup' }).waitFor({ timeout: 15_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Ready for pickup' }).click();
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Picked up' }).waitFor({ timeout: 15_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Picked up' }).click();
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Mark refilled' }).waitFor({ timeout: 15_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Mark refilled' }).click();
+    const refillModal = page.locator('[role="dialog"]', { hasText: `Refill ${name}` });
+    await refillModal.waitFor({ timeout: 5_000 });
+    await refillModal.getByRole('button', { name: /Confirm refill/ }).click();
+    await refillModal.waitFor({ state: 'hidden', timeout: 10_000 });
+    // Fill History section should now be visible with an Active badge
+    await expect(modal.locator('.fill-section-lbl')).toBeVisible();
+    await expect(modal.locator('.badge-current')).toBeVisible();
+  });
+
+  test('future fill date shows queued pill in action row', async ({ page }) => {
+    const name = `[e2e] FutFill ${Date.now()}`;
+    await addMed(page, name);
+    await page.locator('.med-row-main', { hasText: name }).click();
+    const modal = detailModal(page, name);
+    await modal.waitFor({ timeout: 5_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Place request' }).click();
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Ready for pickup' }).waitFor({ timeout: 15_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Ready for pickup' }).click();
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Picked up' }).waitFor({ timeout: 15_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Picked up' }).click();
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Mark refilled' }).waitFor({ timeout: 15_000 });
+    await modal.locator('.med-drawer-actions').getByRole('button', { name: 'Mark refilled' }).click();
+    const refillModal = page.locator('[role="dialog"]', { hasText: `Refill ${name}` });
+    await refillModal.waitFor({ timeout: 5_000 });
+    // Set a future fill date (tomorrow)
+    const tomorrow = new Date(); tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowStr = tomorrow.toISOString().slice(0, 10);
+    await refillModal.locator('input[type="date"]').fill(tomorrowStr);
+    await expect(refillModal.locator('.fr-hint.future')).toBeVisible();
+    await refillModal.getByRole('button', { name: /Queue refill/ }).click();
+    await refillModal.waitFor({ state: 'hidden', timeout: 10_000 });
+    // Queued pill badge should appear in the action row
+    await expect(modal.locator('.queued-pill')).toBeVisible();
+    // Fill History should show a Queued badge
+    await expect(modal.locator('.badge-queued')).toBeVisible();
   });
 
   async function deactivateMed(page, name) {

--- a/client/src/components/chat/AskAiSheet.jsx
+++ b/client/src/components/chat/AskAiSheet.jsx
@@ -36,30 +36,39 @@ function buildSystemContext(meds, apts, tasks, careTeam) {
     weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
   })
 
+  const personLabel = p => p === 'mom' ? 'Mom' : 'Dad'
+
   const medsSection = meds.length === 0 ? 'No medications on file.' : meds.map(m => {
     const { daysToZero, rem } = pillsNow(m)
     const status = supplyStatus(m)
     const label = freqLabel(m)
     const days = daysToZero < 999 ? `${daysToZero} days left` : 'as-needed'
-    return `- ${m.name}${m.dose ? ` ${m.dose}` : ''}${label ? `, ${label}` : ''}: ${rem} pills, ${days} [${status}]`
+    return `- [${personLabel(m.person)}] ${m.name}${m.dose ? ` ${m.dose}` : ''}${label ? `, ${label}` : ''}: ${rem} pills, ${days} [${status}]`
   }).join('\n')
 
   const sorted = [...apts].sort((a, b) => new Date(a.dateTime) - new Date(b.dateTime))
   const upcoming = sorted.filter(a => aptStatus(a) !== 'past')
-  const aptsSection = upcoming.length === 0 ? 'No upcoming appointments.' : upcoming.slice(0, 8).map(a => {
+  const past = sorted.filter(a => aptStatus(a) === 'past').slice(-5)
+
+  const fmtApt = a => {
     const db = fmtAptDateBlock(a.dateTime)
     const time = fmtAptTime(a.dateTime)
     const when = `${db.month} ${db.day}${time ? ` at ${time}` : ''}`
     const dr = a.doctor ? ` with ${a.doctor}` : ''
     const loc = a.location ? ` at ${a.location}` : ''
-    return `- ${when}: ${a.title}${dr}${loc}`
-  }).join('\n')
+    return `- [${personLabel(a.person)}] ${when}: ${a.title}${dr}${loc}`
+  }
+
+  const upcomingSection = upcoming.length === 0 ? 'No upcoming appointments.' : upcoming.slice(0, 8).map(fmtApt).join('\n')
+  const pastSection = past.length === 0 ? 'No past appointments.' : past.map(fmtApt).join('\n')
+  const aptsSection = `Upcoming:\n${upcomingSection}\n\nRecent past (last ${past.length}):\n${pastSection}`
 
   const openTasks = tasks.filter(t => getTaskStatus(t) !== 'done')
   const tasksSection = openTasks.length === 0 ? 'No open tasks.' : openTasks.map(t => {
     const s = getTaskStatus(t)
     const due = t.dueDate ? ` — due ${t.dueDate}` : ''
-    return `- [${s}] ${t.title}${due}`
+    const who = t.person ? ` [${personLabel(t.person)}]` : ''
+    return `- [${s}]${who} ${t.title}${due}`
   }).join('\n')
 
   const careSection = careTeam.length === 0 ? 'No care team on file.' : careTeam.map(d => {
@@ -68,7 +77,7 @@ function buildSystemContext(meds, apts, tasks, careTeam) {
     return `- ${d.name}${spec}${aff}`
   }).join('\n')
 
-  return `You are a helpful assistant for a family caring for their father. Answer questions concisely and accurately based only on the data provided below. Today is ${dateStr}.
+  return `You are a helpful assistant for a family caring for their parents (Mom and Dad). Answer questions concisely and accurately based only on the data provided below. Each item is labeled [Mom] or [Dad]. Today is ${dateStr}.
 
 MEDICATIONS (${meds.length} total):
 ${medsSection}

--- a/client/src/components/meds/MedDetailModal.jsx
+++ b/client/src/components/meds/MedDetailModal.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
-import { fmtDate, getRefillDate } from '../../lib/medUtils'
-import { saveMed, updateRefillStatus, deactivateMed, reactivateMed } from '../../lib/firestore'
+import { fmtDate, fmtShortDate, freqLabel, getRefillDate, activeFill, queuedFill, todayStr } from '../../lib/medUtils'
+import { saveMed, updateRefillStatus, deactivateMed, reactivateMed, removeQueuedFill } from '../../lib/firestore'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import PersonChip from '../PersonChip'
 import RefillModal from './RefillModal'
@@ -114,6 +114,86 @@ function InlineSelect({ field, value, options, placeholder = '', editCtx }) {
   )
 }
 
+function FillEntry({ fill, med, today: todayS }) {
+  const [open, setOpen] = useState(false)
+  const active = activeFill(med)
+  const status = fill.filledDate > todayS ? 'queued'
+    : (active && fill.filledDate === active.filledDate) ? 'current'
+    : 'past'
+
+  const freqText = freqLabel(fill)
+  const summary = [fill.supply ? fill.supply + ' pills' : null, fill.dose || null, freqText || null]
+    .filter(Boolean).join(' · ')
+
+  async function handleRemove(e) {
+    e.stopPropagation()
+    try { await removeQueuedFill(med, fill.id) } catch { alert('Failed to remove. Check your connection.') }
+  }
+
+  return (
+    <div className={`fill-entry ${status}`}>
+      <div className="fill-dot" />
+      <div className="fill-card">
+        <div className="fill-card-head" onClick={() => setOpen(o => !o)}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className="fill-date">{fmtDate(fill.filledDate)}</div>
+            {summary && <div className="fill-summary">{summary}</div>}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+            {status === 'current' && <span className="fill-badge badge-current">Active</span>}
+            {status === 'queued'  && <span className="fill-badge badge-queued">Queued</span>}
+            {status === 'past'    && <span className="fill-badge badge-past">Past</span>}
+            <span className={`fill-chevron${open ? ' open' : ''}`}>▼</span>
+          </div>
+        </div>
+        {open && (
+          <div className="fill-card-body open">
+            <div className="med-drawer-details">
+              <div className="med-drawer-item">
+                <span className="med-drawer-lbl">Fill date</span>
+                <span className="inline-val">{fmtDate(fill.filledDate)}</span>
+              </div>
+              <div className="med-drawer-item">
+                <span className="med-drawer-lbl">Pills in bottle</span>
+                <span className="inline-val">{fill.supply || '—'}</span>
+              </div>
+              <div className="med-drawer-item">
+                <span className="med-drawer-lbl">Dose / strength</span>
+                <span className="inline-val">{fill.dose || '—'}</span>
+              </div>
+              <div className="med-drawer-item">
+                <span className="med-drawer-lbl">Frequency</span>
+                <span className="inline-val">{freqText || '—'}</span>
+              </div>
+              <div className="med-drawer-item">
+                <span className="med-drawer-lbl">Pharmacy</span>
+                <span className="inline-val">{fill.pharmacy || '—'}</span>
+              </div>
+              <div className="med-drawer-item">
+                <span className="med-drawer-lbl">Rx #</span>
+                <span className="inline-val">{fill.rxNum || '—'}</span>
+              </div>
+              <div className="med-drawer-item">
+                <span className="med-drawer-lbl">Doctor</span>
+                <span className="inline-val">{fill.doctor || '—'}</span>
+              </div>
+              {fill.instructions && (
+                <div className="med-drawer-item" style={{ gridColumn: '1 / -1' }}>
+                  <span className="med-drawer-lbl">Instructions</span>
+                  <span className="inline-val">{fill.instructions}</span>
+                </div>
+              )}
+            </div>
+            {status === 'queued' && (
+              <button className="fill-remove" onClick={handleRemove}>Remove queued fill</button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 export default function MedDetailModal({ med, careTeam = [], onClose }) {
   const isMobile = useIsMobile()
   const [editingField, setEditingField] = useState(null)
@@ -136,6 +216,8 @@ export default function MedDetailModal({ med, careTeam = [], onClose }) {
   const rs = m.refillStatus || null
   const rdDate = getRefillDate(m)
   const rd = rdDate ? fmtDate(rdDate) : '—'
+  const queued = queuedFill(m)
+  const todayS = todayStr()
 
   function startEdit(field, currentValue) {
     setEditingField(field)
@@ -199,6 +281,11 @@ export default function MedDetailModal({ med, careTeam = [], onClose }) {
             {saveStatus === 'saving' && 'Saving…'}
             {saveStatus === 'saved'  && 'Saved'}
             {saveStatus === 'error'  && 'Error'}
+          </span>
+        )}
+        {queued && (
+          <span className="queued-pill">
+            ⏱ Next fill {fmtShortDate(queued.filledDate)}
           </span>
         )}
         {isInactive
@@ -302,6 +389,21 @@ export default function MedDetailModal({ med, careTeam = [], onClose }) {
           <InlineTextarea field="instructions" value={m.instructions} placeholder="e.g. Take with food" editCtx={editCtx} />
         </div>
       </div>
+
+      {m.fills?.length > 0 && (
+        <>
+          <div className="fill-section-divider">
+            <span className="fill-section-lbl">Fill History</span>
+          </div>
+          <div className="fill-timeline">
+            {[...m.fills]
+              .sort((a, b) => b.filledDate.localeCompare(a.filledDate))
+              .map(fill => (
+                <FillEntry key={fill.id} fill={fill} med={m} today={todayS} />
+              ))}
+          </div>
+        </>
+      )}
     </>
   )
 

--- a/client/src/components/meds/MedDetailModal.jsx
+++ b/client/src/components/meds/MedDetailModal.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { fmtDate, fmtShortDate, freqLabel, getRefillDate, activeFill, queuedFill, todayStr } from '../../lib/medUtils'
+import { fmtDate, fmtShortDate, freqLabel, freqPerDay, getRefillDate, activeFill, queuedFill, todayStr } from '../../lib/medUtils'
 import { saveMed, updateRefillStatus, deactivateMed, reactivateMed, removeQueuedFill } from '../../lib/firestore'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import PersonChip from '../PersonChip'
@@ -125,6 +125,14 @@ function FillEntry({ fill, med, today: todayS }) {
   const summary = [fill.supply ? fill.supply + ' pills' : null, fill.dose || null, freqText || null]
     .filter(Boolean).join(' · ')
 
+  const runOutDate = (() => {
+    const freq = freqPerDay(fill)
+    if (!freq || freq <= 0 || !fill.filledDate || !fill.supply) return null
+    const d = new Date(fill.filledDate + 'T00:00:00')
+    d.setDate(d.getDate() + Math.ceil(parseInt(fill.supply) / freq))
+    return d
+  })()
+
   async function handleRemove(e) {
     e.stopPropagation()
     try { await removeQueuedFill(med, fill.id) } catch { alert('Failed to remove. Check your connection.') }
@@ -164,6 +172,10 @@ function FillEntry({ fill, med, today: todayS }) {
               <div className="med-drawer-item">
                 <span className="med-drawer-lbl">Frequency</span>
                 <span className="inline-val">{freqText || '—'}</span>
+              </div>
+              <div className="med-drawer-item">
+                <span className="med-drawer-lbl">Runs out</span>
+                <span className="inline-val">{runOutDate ? fmtDate(runOutDate) : '—'}</span>
               </div>
               <div className="med-drawer-item">
                 <span className="med-drawer-lbl">Pharmacy</span>

--- a/client/src/components/meds/MedGroupSection.jsx
+++ b/client/src/components/meds/MedGroupSection.jsx
@@ -9,9 +9,9 @@ const GROUP_META = {
   ok:     { label: 'Stocked up',       variant: 'ok',     defaultOpen: false },
 }
 
-export default function MedGroupSection({ groupKey, meds, sectionRef, onOpen }) {
+export default function MedGroupSection({ groupKey, meds, sectionRef, onOpen, forceOpen = false }) {
   const meta = GROUP_META[groupKey]
-  const [isOpen, setIsOpen] = useState(meta.defaultOpen)
+  const [isOpen, setIsOpen] = useState(meta.defaultOpen || forceOpen)
 
   if (!meds.length) return null
 

--- a/client/src/components/meds/MedicationsView.jsx
+++ b/client/src/components/meds/MedicationsView.jsx
@@ -97,7 +97,8 @@ export default function MedicationsView({ meds, careTeam, personFilter, onPerson
           {filtered.length > 0 && <>
             <MedGroupSection groupKey="urgent" meds={grouped.urgent} sectionRef={urgentRef} onOpen={setViewingMedId} />
             <MedGroupSection groupKey="soon"   meds={grouped.soon}   sectionRef={soonRef}   onOpen={setViewingMedId} />
-            <MedGroupSection groupKey="ok"     meds={grouped.ok}     sectionRef={okRef}     onOpen={setViewingMedId} />
+            <MedGroupSection groupKey="ok"     meds={grouped.ok}     sectionRef={okRef}     onOpen={setViewingMedId}
+              forceOpen={!grouped.urgent.length && !grouped.soon.length} />
           </>}
           {inactiveMeds.length > 0 && (
             <div className="med-group med-group-inactive">

--- a/client/src/components/meds/RefillModal.jsx
+++ b/client/src/components/meds/RefillModal.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { markRefilled } from '../../lib/firestore'
 import { useIsMobile } from '../../hooks/useIsMobile'
-import { todayStr, freqPerDay, fmtDate } from '../../lib/medUtils'
+import { todayStr, today, daysBetween, freqPerDay, fmtDate, fmtShortDate } from '../../lib/medUtils'
 
 const PRESETS = [
   { value: 'once-daily',      label: 'Once daily' },
@@ -45,12 +45,27 @@ export default function RefillModal({ med, onClose }) {
     setSaving(false)
   }
 
+  const isFuture = form.filledDate && form.filledDate > todayStr()
+  const daysAway = isFuture
+    ? daysBetween(today(), new Date(form.filledDate + 'T00:00:00'))
+    : null
+
   const formContent = (
     <>
       <div className="fr">
         <label>Fill date <span className="req">*</span></label>
         <input type="date" value={form.filledDate} onChange={set('filledDate')} />
+        {isFuture && (
+          <div className="fr-hint future">In {daysAway} day{daysAway !== 1 ? 's' : ''}</div>
+        )}
       </div>
+
+      {isFuture && (
+        <div className="fr-hint-box future">
+          Queued for {fmtShortDate(form.filledDate)} — current supply stays active until then
+        </div>
+      )}
+
       <div className="f2">
         <div className="fr">
           <label>Pills in bottle <span className="req">*</span></label>
@@ -94,7 +109,10 @@ export default function RefillModal({ med, onClose }) {
         d.setDate(d.getDate() + days)
         return (
           <div className="fr-hint" style={{ marginBottom: 4 }}>
-            Runs out approx. {fmtDate(d)}
+            {isFuture
+              ? <>Runs out approx. {fmtDate(d)} ({days}d from {fmtShortDate(form.filledDate)})</>
+              : <>Runs out approx. {fmtDate(d)}</>
+            }
           </div>
         )
       })()}
@@ -102,7 +120,7 @@ export default function RefillModal({ med, onClose }) {
       <div className="mf">
         <button className="btn-cx" onClick={onClose}>Cancel</button>
         <button className="btn-sv" onClick={handleConfirm} disabled={saving}>
-          {saving ? 'Saving…' : 'Confirm refill'}
+          {saving ? 'Saving…' : isFuture ? 'Queue refill' : 'Confirm refill'}
         </button>
       </div>
     </>

--- a/client/src/hooks/useMeds.js
+++ b/client/src/hooks/useMeds.js
@@ -1,12 +1,40 @@
 import { useState, useEffect } from 'react'
-import { collection, onSnapshot } from 'firebase/firestore'
+import { collection, onSnapshot, writeBatch, doc } from 'firebase/firestore'
 import { db } from '../firebase'
+import { newId } from '../lib/firestore'
 
 export function useMeds() {
   const [meds, setMeds] = useState([])
   useEffect(() => {
     return onSnapshot(collection(db, 'medications'), snap => {
-      setMeds(snap.docs.map(d => { const data = d.data(); return { ...data, person: data.person || 'dad' } }))
+      const docs = snap.docs.map(d => { const data = d.data(); return { ...data, person: data.person || 'dad' } })
+      setMeds(docs)
+
+      // One-time migration: seed fills[] from top-level fields for pre-feature meds
+      const toMigrate = docs.filter(m => !m.fills?.length && m.filledDate)
+      if (toMigrate.length) {
+        const batch = writeBatch(db)
+        toMigrate.forEach(m => {
+          const initialFill = {
+            id: newId(),
+            filledDate: m.filledDate,
+            supply: m.supply,
+            dose: m.dose || '',
+            frequency: m.frequency,
+            frequencyPreset: m.frequencyPreset || 'once-daily',
+            frequencyCustomCount: m.frequencyCustomCount || '1',
+            frequencyCustomEvery: m.frequencyCustomEvery || '1',
+            frequencyCustomUnit: m.frequencyCustomUnit || 'days',
+            pharmacy: m.pharmacy || '',
+            rxNum: m.rxNum || '',
+            doctor: m.doctor || '',
+            instructions: m.instructions || '',
+            createdAt: m.updatedAt || new Date().toISOString(),
+          }
+          batch.update(doc(db, 'medications', m.id), { fills: [initialFill] })
+        })
+        batch.commit().catch(err => console.error('fills migration error:', err))
+      }
     }, err => console.error('Firestore meds error:', err))
   }, [])
   return meds

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1221,6 +1221,38 @@ tbody tr:hover{background:rgba(50,20,20,.028)}
 }
 .stk-show-btn:hover{background:var(--green-dim)}
 
+/* ── Fill history ── */
+.queued-pill{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;padding:4px 10px;border-radius:20px;background:var(--violet-dim);color:var(--violet);border:1px solid var(--violet-border);font-family:var(--ffm)}
+.fill-section-divider{display:flex;align-items:center;gap:8px;margin:20px 0 14px;padding-top:16px;border-top:1px solid var(--border)}
+.fill-section-lbl{font-size:10px;font-weight:700;letter-spacing:.6px;text-transform:uppercase;color:var(--text3)}
+.fill-timeline{position:relative;padding-left:20px}
+.fill-timeline::before{content:'';position:absolute;left:6px;top:8px;bottom:8px;width:1px;background:var(--border2)}
+.fill-entry{position:relative;margin-bottom:8px}
+.fill-dot{position:absolute;left:-17px;top:13px;width:9px;height:9px;border-radius:50%;border:2px solid var(--panel);background:var(--border2)}
+.fill-entry.current .fill-dot{background:var(--blue)}
+.fill-entry.queued .fill-dot{background:var(--violet)}
+.fill-card{border:1px solid var(--border2);border-radius:9px;overflow:hidden;background:var(--panel)}
+.fill-entry.current .fill-card{border-color:var(--blue-border)}
+.fill-entry.queued .fill-card{border-color:var(--violet-border)}
+.fill-entry.past .fill-card{opacity:.55}
+.fill-card-head{display:flex;align-items:center;justify-content:space-between;padding:9px 12px 8px;cursor:pointer;gap:8px;user-select:none}
+.fill-date{font-size:12px;font-weight:600;font-family:var(--ffm);color:var(--text)}
+.fill-entry.past .fill-date{color:var(--text2)}
+.fill-summary{font-size:11px;color:var(--text2);margin-top:2px}
+.fill-badge{font-size:10px;font-weight:600;padding:1px 7px;border-radius:20px;font-family:var(--ffm)}
+.badge-current{background:var(--blue-dim);color:var(--blue);border:1px solid var(--blue-border)}
+.badge-queued{background:var(--violet-dim);color:var(--violet);border:1px solid var(--violet-border)}
+.badge-past{background:var(--panel2);color:var(--text3)}
+.fill-chevron{font-size:10px;color:var(--text3);transition:transform .18s}
+.fill-chevron.open{transform:rotate(180deg)}
+.fill-card-body{padding:0 12px 12px}
+.fill-card-body .med-drawer-details{gap:8px 16px;margin-top:8px}
+.fill-remove{margin-top:10px;font-family:var(--ff);font-size:11px;font-weight:500;background:none;border:1px solid var(--red-border);color:var(--red);padding:4px 10px;border-radius:6px;cursor:pointer}
+/* RefillModal future date */
+.fr-hint.future{color:var(--violet);font-weight:600}
+.fr-hint-box{padding:8px 12px;border-radius:7px;font-size:12px;margin-bottom:4px}
+.fr-hint-box.future{background:var(--violet-dim);color:var(--violet);border:1px solid var(--violet-border)}
+
 /* ── TABLET  640–1023px ── */
 @media(min-width:640px) and (max-width:1023px){
   .lbl-full{display:none}
@@ -1249,6 +1281,7 @@ tbody tr:hover{background:rgba(50,20,20,.028)}
   .med-col-pharm{display:none}
   .med-col-menu{display:none}
   .drawer-deactivate{display:block}
+  .fill-dot{border-color:var(--bg)}
   /* Status col becomes vertical: pill + mini bar */
   .med-col-status{display:flex;flex-direction:column;align-items:flex-end;gap:5px}
   .med-mobile-pills{display:flex}

--- a/client/src/lib/firestore.js
+++ b/client/src/lib/firestore.js
@@ -62,21 +62,80 @@ export async function reactivateMed(id) {
 
 export async function markRefilled(med, overrides = {}) {
   const hasFreq = overrides.frequencyPreset !== undefined
+  const fillDate = overrides.filledDate || todayStr()
+  const isFuture = fillDate > todayStr()
+
+  const newFill = {
+    id: newId(),
+    filledDate: fillDate,
+    supply: overrides.supply ?? med.supply,
+    dose: overrides.dose ?? med.dose ?? '',
+    frequency: hasFreq ? computeFrequency(overrides) : med.frequency,
+    frequencyPreset: hasFreq ? overrides.frequencyPreset : (med.frequencyPreset || 'once-daily'),
+    frequencyCustomCount: hasFreq ? (overrides.frequencyCustomCount || '1') : (med.frequencyCustomCount || '1'),
+    frequencyCustomEvery: hasFreq ? (overrides.frequencyCustomEvery || '1') : (med.frequencyCustomEvery || '1'),
+    frequencyCustomUnit: hasFreq ? (overrides.frequencyCustomUnit || 'days') : (med.frequencyCustomUnit || 'days'),
+    pharmacy: med.pharmacy || '',
+    rxNum: med.rxNum || '',
+    doctor: med.doctor || '',
+    instructions: med.instructions || '',
+    createdAt: new Date().toISOString(),
+  }
+
+  // Archive current top-level fill if not already in fills[]
+  const existingFills = med.fills || []
+  const alreadyArchived = existingFills.some(f => f.filledDate === med.filledDate)
+  const priorFills = alreadyArchived
+    ? existingFills
+    : med.filledDate
+      ? [...existingFills, {
+          id: newId(),
+          filledDate: med.filledDate,
+          supply: med.supply,
+          dose: med.dose || '',
+          frequency: med.frequency,
+          frequencyPreset: med.frequencyPreset || 'once-daily',
+          frequencyCustomCount: med.frequencyCustomCount || '1',
+          frequencyCustomEvery: med.frequencyCustomEvery || '1',
+          frequencyCustomUnit: med.frequencyCustomUnit || 'days',
+          pharmacy: med.pharmacy || '',
+          rxNum: med.rxNum || '',
+          doctor: med.doctor || '',
+          instructions: med.instructions || '',
+          createdAt: med.updatedAt || new Date().toISOString(),
+        }]
+      : existingFills
+
   const updated = {
     ...med,
-    filledDate: overrides.filledDate || todayStr(),
-    supply: overrides.supply ?? med.supply,
-    dose: overrides.dose ?? med.dose,
-    ...(hasFreq && {
-      frequency: computeFrequency(overrides),
-      frequencyPreset: overrides.frequencyPreset,
-      frequencyCustomCount: overrides.frequencyCustomCount || '1',
-      frequencyCustomEvery: overrides.frequencyCustomEvery || '1',
-      frequencyCustomUnit: overrides.frequencyCustomUnit || 'days',
-    }),
+    fills: [...priorFills, newFill],
     refillDate: '',
     refillStatus: null,
-    updatedAt: new Date().toISOString()
+    updatedAt: new Date().toISOString(),
+  }
+
+  // Only promote top-level fields for today/past fills
+  if (!isFuture) {
+    updated.filledDate = fillDate
+    updated.supply = newFill.supply
+    updated.dose = newFill.dose
+    if (hasFreq) {
+      updated.frequency = newFill.frequency
+      updated.frequencyPreset = newFill.frequencyPreset
+      updated.frequencyCustomCount = newFill.frequencyCustomCount
+      updated.frequencyCustomEvery = newFill.frequencyCustomEvery
+      updated.frequencyCustomUnit = newFill.frequencyCustomUnit
+    }
+  }
+
+  await setDoc(doc(db, 'medications', med.id), updated)
+}
+
+export async function removeQueuedFill(med, fillId) {
+  const updated = {
+    ...med,
+    fills: (med.fills || []).filter(f => f.id !== fillId),
+    updatedAt: new Date().toISOString(),
   }
   await setDoc(doc(db, 'medications', med.id), updated)
 }

--- a/client/src/lib/firestore.js
+++ b/client/src/lib/firestore.js
@@ -49,6 +49,34 @@ export async function saveMed(fields, editId) {
     person: fields.person || 'dad',
     updatedAt: new Date().toISOString()
   }
+
+  // Preserve fills[] and keep the active fill entry in sync with top-level field edits
+  if (fields.fills?.length) {
+    const t = todayStr()
+    const activeIdx = fields.fills.reduce((best, f, i) => {
+      if (f.filledDate > t) return best
+      if (best === -1) return i
+      return f.filledDate > fields.fills[best].filledDate ? i : best
+    }, -1)
+    med.fills = activeIdx === -1
+      ? fields.fills
+      : fields.fills.map((f, i) => i !== activeIdx ? f : {
+          ...f,
+          filledDate: med.filledDate,
+          supply: med.supply,
+          dose: med.dose,
+          frequency: med.frequency,
+          frequencyPreset: med.frequencyPreset,
+          frequencyCustomCount: med.frequencyCustomCount,
+          frequencyCustomEvery: med.frequencyCustomEvery,
+          frequencyCustomUnit: med.frequencyCustomUnit,
+          pharmacy: med.pharmacy,
+          rxNum: med.rxNum,
+          doctor: med.doctor,
+          instructions: med.instructions,
+        })
+  }
+
   await setDoc(doc(db, 'medications', med.id), med)
 }
 

--- a/client/src/lib/medUtils.js
+++ b/client/src/lib/medUtils.js
@@ -51,10 +51,47 @@ export function freqLabel(m) {
   return `${f}× daily`
 }
 
+// Returns the currently active fill (most recent whose filledDate <= today).
+// Falls back to top-level fields for meds not yet migrated.
+export function activeFill(med) {
+  const t = todayStr()
+  const past = (med.fills || []).filter(f => f.filledDate <= t)
+  if (past.length) return past.sort((a, b) => b.filledDate.localeCompare(a.filledDate))[0]
+  // pre-migration fallback
+  return {
+    filledDate: med.filledDate,
+    supply: med.supply,
+    dose: med.dose,
+    frequencyPreset: med.frequencyPreset,
+    frequencyCustomCount: med.frequencyCustomCount,
+    frequencyCustomEvery: med.frequencyCustomEvery,
+    frequencyCustomUnit: med.frequencyCustomUnit,
+  }
+}
+
+// Returns the single queued (future-dated) fill, or null.
+export function queuedFill(med) {
+  const t = todayStr()
+  return (med.fills || []).find(f => f.filledDate > t) || null
+}
+
+// Total days of supply coverage: current + queued fill (if any).
+function effectiveDaysToZero(m) {
+  const p = pillsNow(m)
+  const qf = queuedFill(m)
+  if (!qf) return p.daysToZero
+  const freq = freqPerDay({ ...m, ...qf })
+  if (!freq || freq <= 0) return p.daysToZero
+  const queuedFillDate = new Date(qf.filledDate + 'T00:00:00')
+  const daysUntilQueued = Math.max(0, daysBetween(today(), queuedFillDate))
+  return daysUntilQueued + Math.ceil((parseInt(qf.supply) || 30) / freq)
+}
+
 export function pillsNow(m) {
-  const freq = freqPerDay(m)
-  const supply = parseInt(m.supply) || 30
-  const filledDate = m.filledDate ? new Date(m.filledDate + 'T00:00:00') : null
+  const fill = activeFill(m)
+  const freq = freqPerDay({ ...m, ...fill })
+  const supply = parseInt(fill.supply) || 30
+  const filledDate = fill.filledDate ? new Date(fill.filledDate + 'T00:00:00') : null
   if (!filledDate) return { rem: supply, tot: supply, runOutDate: null, daysToZero: 999 }
   if (freq === null) {
     // as-needed: track pills only, no runout math
@@ -76,17 +113,16 @@ export function getRefillDate(m) {
 const REFILL_LEAD = 14
 
 export function supplyStatus(m) {
-  const p = pillsNow(m)
-  if (p.rem <= 0) return 'urgent'
-  if (p.daysToZero <= 7) return 'urgent'
-  if (p.daysToZero <= REFILL_LEAD) return 'soon'
+  const d = effectiveDaysToZero(m)
+  if (d <= 7) return 'urgent'
+  if (d <= REFILL_LEAD) return 'soon'
   return 'ok'
 }
 
 export function supplyStatusLabel(m) {
   const p = pillsNow(m)
-  if (p.rem <= 0) return 'Out of pills'
-  const d = p.daysToZero
+  if (p.rem <= 0 && !queuedFill(m)) return 'Out of pills'
+  const d = effectiveDaysToZero(m)
   if (d <= 0) return 'Out of pills'
   if (d <= 7) return d === 1 ? 'Refill today' : 'Refill in ' + d + 'd'
   if (d <= REFILL_LEAD) return 'Refill in ' + d + 'd'

--- a/client/src/test/medUtils.test.js
+++ b/client/src/test/medUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { pillsNow, supplyStatus, supplyStatusLabel, pillStatusClass, fmtDate, today, freqPerDay, freqLabel } from '../lib/medUtils'
+import { pillsNow, supplyStatus, supplyStatusLabel, pillStatusClass, fmtDate, today, freqPerDay, freqLabel, activeFill, queuedFill } from '../lib/medUtils'
 
 // Pin "today" to a fixed date for deterministic tests
 const FIXED_TODAY = new Date('2026-03-31T00:00:00')
@@ -152,6 +152,90 @@ describe('supplyStatusLabel', () => {
   it('returns "OK — Xd left" when stocked', () => {
     const med = { filledDate: '2026-03-31', supply: 30, frequency: 1 }
     expect(supplyStatusLabel(med)).toBe('OK — 30d left')
+  })
+})
+
+// ── activeFill ────────────────────────────────────────────────────────────────
+
+describe('activeFill', () => {
+  it('returns most recent past fill from fills[]', () => {
+    const med = {
+      fills: [
+        { id: 'a', filledDate: '2026-03-01', supply: 30 },
+        { id: 'b', filledDate: '2026-03-20', supply: 30 },
+      ]
+    }
+    expect(activeFill(med).id).toBe('b')
+  })
+
+  it('ignores future fills', () => {
+    const med = {
+      fills: [
+        { id: 'past', filledDate: '2026-03-01', supply: 30 },
+        { id: 'future', filledDate: '2026-04-10', supply: 30 },
+      ]
+    }
+    expect(activeFill(med).id).toBe('past')
+  })
+
+  it('falls back to top-level fields when fills[] is empty', () => {
+    const med = { filledDate: '2026-03-31', supply: 30, frequencyPreset: 'once-daily' }
+    const fill = activeFill(med)
+    expect(fill.filledDate).toBe('2026-03-31')
+    expect(fill.supply).toBe(30)
+  })
+
+  it('falls back to top-level fields when fills[] is absent', () => {
+    const med = { filledDate: '2026-03-15', supply: 60 }
+    expect(activeFill(med).filledDate).toBe('2026-03-15')
+  })
+})
+
+// ── queuedFill ────────────────────────────────────────────────────────────────
+
+describe('queuedFill', () => {
+  it('returns future fill', () => {
+    const med = {
+      fills: [
+        { id: 'past',   filledDate: '2026-03-01', supply: 30 },
+        { id: 'future', filledDate: '2026-04-10', supply: 30 },
+      ]
+    }
+    expect(queuedFill(med).id).toBe('future')
+  })
+
+  it('returns null when no future fill', () => {
+    const med = {
+      fills: [{ id: 'past', filledDate: '2026-03-01', supply: 30 }]
+    }
+    expect(queuedFill(med)).toBeNull()
+  })
+
+  it('returns null when fills[] is absent', () => {
+    expect(queuedFill({ filledDate: '2026-03-01', supply: 30 })).toBeNull()
+  })
+})
+
+// ── supplyStatus with queued fill ─────────────────────────────────────────────
+
+describe('supplyStatus with queued fill', () => {
+  it('returns ok when current supply is urgent but queued fill covers gap', () => {
+    const med = {
+      fills: [
+        { id: 'cur', filledDate: '2026-03-29', supply: 3, frequencyPreset: 'once-daily' },
+        { id: 'q',   filledDate: '2026-04-05', supply: 30, frequencyPreset: 'once-daily' },
+      ],
+      filledDate: '2026-03-29', supply: 3, frequencyPreset: 'once-daily'
+    }
+    expect(supplyStatus(med)).toBe('ok')
+  })
+
+  it('returns urgent when no queued fill and supply ≤7 days', () => {
+    const med = {
+      fills: [{ id: 'cur', filledDate: '2026-03-29', supply: 3, frequencyPreset: 'once-daily' }],
+      filledDate: '2026-03-29', supply: 3, frequencyPreset: 'once-daily'
+    }
+    expect(supplyStatus(med)).toBe('urgent')
   })
 })
 


### PR DESCRIPTION
## Summary

- **Fill history**: Every medication now shows a chronological Fill History section in the detail modal — past fills (greyed), the active supply (highlighted), and any queued future fills (violet). Entries are collapsed by default and expand to show all fields including run-out date.
- **Future-dated refills**: When marking a medication refilled, you can set a future fill date. The new bottle queues up and activates automatically on that date — the current supply countdown is unaffected until then. A violet "Next fill [date]" badge appears in the action row.
- **Supply status with queued fills**: `supplyStatus()` now considers the queued bottle's coverage, so a med showing 3 days left but with a 30-day refill queued reads as OK rather than urgent.
- **Auto-migration**: Existing medications are automatically seeded into `fills[]` on first load — no manual migration needed.
- **Bug fix**: `saveMed()` was wiping `fills[]` on every inline edit. Fixed to preserve fill history and keep the active fill entry in sync with top-level field changes.
- **Stocked group auto-expands** when there are no urgent or soon medications.

## Test plan

- [ ] Open a medication detail — Fill History section shows with one Active entry (migrated from existing data)
- [ ] Mark a medication refilled with today's date — new Active entry appears, old one becomes Past
- [ ] Mark a medication refilled with a future date — Queued badge appears in action row; current supply countdown unchanged
- [ ] Inline-edit `supply` or `filledDate` — Fill History Active entry updates to match
- [ ] When no urgent/soon meds exist, Stocked Up group opens by default
- [ ] Unit tests: `npm run test:run` — 71 passed
- [ ] E2E tests: fill history and future fill tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)