### PR TITLE
Add 'What it's for' purpose field to medications

### DIFF
--- a/client/src/components/meds/MedDetailModal.jsx
+++ b/client/src/components/meds/MedDetailModal.jsx
@@ -344,6 +344,11 @@ export default function MedDetailModal({ med, careTeam = [], onClose }) {
           <InlineField field="name" value={m.name} placeholder="e.g. Metformin" editCtx={editCtx} />
         </div>
 
+        <div className="med-drawer-item" style={{ gridColumn: '1 / -1' }}>
+          <span className="med-drawer-lbl">What it&apos;s for</span>
+          <InlineField field="purpose" value={m.purpose} placeholder="e.g. Blood pressure" editCtx={editCtx} />
+        </div>
+
         <div className="med-drawer-item">
           <span className="med-drawer-lbl">Dose / strength</span>
           <InlineField field="dose" value={m.dose} placeholder="e.g. 500 mg" editCtx={editCtx} />

--- a/client/src/components/meds/MedModal.jsx
+++ b/client/src/components/meds/MedModal.jsx
@@ -4,7 +4,7 @@ import { useIsMobile } from '../../hooks/useIsMobile'
 import { freqPerDay, fmtDate } from '../../lib/medUtils'
 
 const EMPTY = {
-  name: '', dose: '', frequencyPreset: 'once-daily',
+  name: '', dose: '', purpose: '', frequencyPreset: 'once-daily',
   frequencyCustomCount: '1', frequencyCustomEvery: '1', frequencyCustomUnit: 'days',
   filledDate: '', supply: '', pharmacy: '', rxNum: '',
   doctor: '', instructions: '', person: 'dad'
@@ -115,6 +115,10 @@ export default function MedModal({ careTeam = [], onClose }) {
       })()}
 
       <div className="sheet-section">Optional</div>
+      <div className="fr">
+        <label>What it&apos;s for</label>
+        <input value={form.purpose} onChange={set('purpose')} placeholder="e.g. Blood pressure" />
+      </div>
       <div className="fr">
         <label>Dose / strength</label>
         <input value={form.dose} onChange={set('dose')} placeholder="e.g. 500 mg" />

--- a/client/src/components/meds/MedRow.jsx
+++ b/client/src/components/meds/MedRow.jsx
@@ -12,7 +12,7 @@ export default function MedRow({ m, onOpen }) {
   const bc = pc === 'zero' || pc === 'low' ? 'var(--red)' : s === 'soon' ? 'var(--amber)' : 'var(--green)'
   const pillSt = p.rem <= 0 ? 'empty' : s
   const fl = freqLabel(m)
-  const sub = [m.dose, m.rxNum ? 'Rx ' + m.rxNum : '', fl].filter(Boolean).join(' · ')
+  const sub = [m.purpose, m.dose, m.rxNum ? 'Rx ' + m.rxNum : '', fl].filter(Boolean).join(' · ')
   const rdDate = getRefillDate(m)
   const rd = rdDate ? fmtDate(rdDate) : '—'
 

--- a/client/src/lib/firestore.js
+++ b/client/src/lib/firestore.js
@@ -45,6 +45,7 @@ export async function saveMed(fields, editId) {
     rxNum: fields.rxNum,
     doctor: fields.doctor,
     instructions: fields.instructions,
+    purpose: fields.purpose || '',
     active: fields.active ?? true,
     person: fields.person || 'dad',
     updatedAt: new Date().toISOString()


### PR DESCRIPTION
Adds an optional free-text field describing what a medication treats
(e.g. "Blood pressure", "Diabetes"). Visible in the add modal, the
detail drawer (inline-editable), and as the first item in the MedRow
subtitle.

https://claude.ai/code/session_01BAGVK4aNbiVJCU6dLkimrE