### PR TITLE
Add separate As Needed section to medications page

### DIFF
--- a/client/src/components/meds/MedGroupSection.jsx
+++ b/client/src/components/meds/MedGroupSection.jsx
@@ -4,9 +4,10 @@ import MedRow from './MedRow'
 import MedStockedCollapsed from './MedStockedCollapsed'
 
 const GROUP_META = {
-  urgent: { label: 'Refill urgently', variant: 'urgent', defaultOpen: true },
-  soon:   { label: 'Refill in 2 weeks', variant: 'soon',   defaultOpen: true },
-  ok:     { label: 'Stocked up',       variant: 'ok',     defaultOpen: false },
+  urgent:      { label: 'Refill urgently',   variant: 'urgent',     defaultOpen: true  },
+  soon:        { label: 'Refill in 2 weeks', variant: 'soon',       defaultOpen: true  },
+  ok:          { label: 'Stocked up',        variant: 'ok',         defaultOpen: false },
+  'as-needed': { label: 'As needed',         variant: 'as-needed',  defaultOpen: true  },
 }
 
 export default function MedGroupSection({ groupKey, meds, sectionRef, onOpen, forceOpen = false }) {

--- a/client/src/components/meds/MedicationsView.jsx
+++ b/client/src/components/meds/MedicationsView.jsx
@@ -28,9 +28,10 @@ export default function MedicationsView({ meds, careTeam, personFilter, onPerson
   const [viewingMedId, setViewingMedId] = useState(null)
   const fileRef = useRef()
 
-  const urgentRef = useRef()
-  const soonRef   = useRef()
-  const okRef     = useRef()
+  const urgentRef    = useRef()
+  const soonRef      = useRef()
+  const okRef        = useRef()
+  const asNeededRef  = useRef()
 
   async function handleImport(e) {
     const file = e.target.files[0]; if (!file) return
@@ -47,7 +48,22 @@ export default function MedicationsView({ meds, careTeam, personFilter, onPerson
   const inactiveMeds = useMemo(() => meds.filter(m => m.active === false), [meds])
 
   const filtered = useMemo(() => {
-    let rows = [...filterByPerson(activeMeds, personFilter)].sort((a, b) => pillsNow(a).daysToZero - pillsNow(b).daysToZero)
+    let rows = filterByPerson(activeMeds, personFilter)
+      .filter(m => m.frequencyPreset !== 'as-needed')
+      .sort((a, b) => pillsNow(a).daysToZero - pillsNow(b).daysToZero)
+    if (q) rows = rows.filter(m =>
+      m.name.toLowerCase().includes(q) ||
+      (m.brandName || '').toLowerCase().includes(q) ||
+      (m.pharmacy || '').toLowerCase().includes(q) ||
+      (m.doctor || '').toLowerCase().includes(q)
+    )
+    return rows
+  }, [activeMeds, personFilter, q])
+
+  const asNeededMeds = useMemo(() => {
+    let rows = filterByPerson(activeMeds, personFilter)
+      .filter(m => m.frequencyPreset === 'as-needed')
+      .sort((a, b) => a.name.localeCompare(b.name))
     if (q) rows = rows.filter(m =>
       m.name.toLowerCase().includes(q) ||
       (m.brandName || '').toLowerCase().includes(q) ||
@@ -87,7 +103,7 @@ export default function MedicationsView({ meds, careTeam, personFilter, onPerson
         </div>
       </div>
 
-      {filtered.length === 0 && inactiveMeds.length === 0 ? (
+      {filtered.length === 0 && asNeededMeds.length === 0 && inactiveMeds.length === 0 ? (
         <div className="med-empty">
           {meds.length === 0
             ? 'No medications yet. Click "+ Add medication" to get started.'
@@ -101,6 +117,7 @@ export default function MedicationsView({ meds, careTeam, personFilter, onPerson
             <MedGroupSection groupKey="ok"     meds={grouped.ok}     sectionRef={okRef}     onOpen={setViewingMedId}
               forceOpen={!grouped.urgent.length && !grouped.soon.length} />
           </>}
+          <MedGroupSection groupKey="as-needed" meds={asNeededMeds} sectionRef={asNeededRef} onOpen={setViewingMedId} />
           {inactiveMeds.length > 0 && (
             <div className="med-group med-group-inactive">
               <MedGroupHeader

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1112,6 +1112,8 @@ tbody tr:hover{background:rgba(50,20,20,.028)}
 .med-group-ok       .med-group-body{border-left:2px solid var(--green);border-radius:0 10px 10px 0}
 .med-group-inactive .med-group-body{border-left:2px solid var(--text3);border-radius:0 10px 10px 0}
 .med-group-hdr-inactive .med-group-label{color:var(--text3)}
+.med-group-as-needed .med-group-body{border-left:2px solid var(--violet);border-radius:0 10px 10px 0}
+.med-group-hdr-as-needed .med-group-label{color:var(--violet)}
 .med-row-inactive .med-row-main{opacity:.45}
 .med-row-inactive .med-row-main:hover{opacity:.7}
 

--- a/client/src/lib/medUtils.js
+++ b/client/src/lib/medUtils.js
@@ -120,6 +120,7 @@ export function supplyStatus(m) {
 }
 
 export function supplyStatusLabel(m) {
+  if (m.frequencyPreset === 'as-needed') return 'As needed'
   const p = pillsNow(m)
   if (p.rem <= 0 && !queuedFill(m)) return 'Out of pills'
   const d = effectiveDaysToZero(m)


### PR DESCRIPTION
Medications with frequencyPreset 'as-needed' now appear in their own
collapsible section below the supply groups instead of landing in
Stocked Up. supplyStatusLabel also returns 'As needed' for these meds
so the status badge shows meaningful text rather than 'OK — 999d left'.

https://claude.ai/code/session_01SKuZCD4hZ8Aova84Hies2s