### PR TITLE
fix: sort and color meds by effectiveDaysToZero (including queued fills)

### DIFF
--- a/client/src/components/meds/MedRow.jsx
+++ b/client/src/components/meds/MedRow.jsx
@@ -10,6 +10,7 @@ export default function MedRow({ m, onOpen }) {
   const pct = p.tot > 0 ? Math.round((p.rem / p.tot) * 100) : 0
   const pc = pillStatusClass(p.rem, p.tot)
   const bc = pc === 'zero' || pc === 'low' ? 'var(--red)' : s === 'soon' ? 'var(--amber)' : 'var(--green)'
+  const daysCls = p.rem <= 0 ? 'zero' : s === 'urgent' ? 'zero' : s === 'soon' ? 'low' : 'ok'
   const pillSt = p.rem <= 0 ? 'empty' : s
   const fl = freqLabel(m)
   const sub = [m.brandName || null, m.purpose, m.dose, m.rxNum ? 'Rx ' + m.rxNum : '', fl].filter(Boolean).join(' · ')
@@ -39,7 +40,7 @@ export default function MedRow({ m, onOpen }) {
 
         <div className="med-col-pills">
           <div className="pills-top">
-            <span className={`pill-count ${pc}`}>
+            <span className={`pill-count ${p.daysToZero === 999 ? pc : daysCls}`}>
               {p.daysToZero === 999 ? p.rem : p.daysToZero}
             </span>
             <span className="pill-of">{p.daysToZero === 999 ? 'pills' : 'd'}</span>
@@ -56,7 +57,7 @@ export default function MedRow({ m, onOpen }) {
           <span className={`spill sp-${pillSt}`}>{lbl}</span>
           {rsl && <span className="refill-status-badge">{rsl}</span>}
           <div className="med-mobile-pills">
-            <span className={`med-mobile-count ${pc}`}>
+            <span className={`med-mobile-count ${p.daysToZero === 999 ? pc : daysCls}`}>
               {p.daysToZero === 999 ? p.rem : p.daysToZero}
               <span className="med-mobile-of">{p.daysToZero === 999 ? 'p' : 'd'}</span>
             </span>

--- a/client/src/components/meds/MedicationsView.jsx
+++ b/client/src/components/meds/MedicationsView.jsx
@@ -5,7 +5,7 @@ import MedModal from './MedModal'
 import MedDetailModal from './MedDetailModal'
 import MedGroupHeader from './MedGroupHeader'
 import { exportCSV, exportJSON, importMeds } from '../../lib/firestore'
-import { supplyStatus, pillsNow } from '../../lib/medUtils'
+import { supplyStatus, effectiveDaysToZero } from '../../lib/medUtils'
 import { filterByPerson } from '../MainApp'
 import PersonChip from '../PersonChip'
 
@@ -50,7 +50,7 @@ export default function MedicationsView({ meds, careTeam, personFilter, onPerson
   const filtered = useMemo(() => {
     let rows = filterByPerson(activeMeds, personFilter)
       .filter(m => m.frequencyPreset !== 'as-needed')
-      .sort((a, b) => pillsNow(a).daysToZero - pillsNow(b).daysToZero)
+      .sort((a, b) => effectiveDaysToZero(a) - effectiveDaysToZero(b))
     if (q) rows = rows.filter(m =>
       m.name.toLowerCase().includes(q) ||
       (m.brandName || '').toLowerCase().includes(q) ||

--- a/client/src/components/meds/MedsTable.jsx
+++ b/client/src/components/meds/MedsTable.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { pillsNow, supplyStatus, supplyStatusLabel, pillStatusClass, fmtDate, getRefillDate, freqLabel } from '../../lib/medUtils'
+import { pillsNow, supplyStatus, supplyStatusLabel, pillStatusClass, fmtDate, getRefillDate, freqLabel, effectiveDaysToZero } from '../../lib/medUtils'
 import { delMed } from '../../lib/firestore'
 import RefillModal from './RefillModal'
 
@@ -7,7 +7,7 @@ export default function MedsTable({ meds, filter, search, onEdit }) {
   const [refillMed, setRefillMed] = useState(null)
   const q = search.toLowerCase()
 
-  let rows = [...meds].sort((a, b) => pillsNow(a).daysToZero - pillsNow(b).daysToZero)
+  let rows = [...meds].sort((a, b) => effectiveDaysToZero(a) - effectiveDaysToZero(b))
   if (filter !== 'all') rows = rows.filter(m => supplyStatus(m) === filter)
   if (q) rows = rows.filter(m =>
     m.name.toLowerCase().includes(q) ||

--- a/client/test-results/.last-run.json
+++ b/client/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
Sort order and days-counter color were both using pillsNow().daysToZero
(current fill only), ignoring any queued future fill. This caused meds
with a pending refill to sort as if nearly empty and display their days
count in amber even when their effective supply status was OK.

Fix sorts in MedicationsView and MedsTable to use effectiveDaysToZero.
Fix MedRow days-counter color (desktop + mobile) to derive from supply
status (effectiveDaysToZero-based) rather than physical pill percentage,
keeping the days number color consistent with the status badge.

https://claude.ai/code/session_01AAJ3ixsRUXM3wzAfSJHMWa