### PR TITLE
Add Manage Dad's Data section (soft/hard delete)

### DIFF
--- a/client/src/components/DataManagementView.jsx
+++ b/client/src/components/DataManagementView.jsx
@@ -1,0 +1,213 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  PERSON_COLLECTIONS,
+  countPersonData,
+  softDeletePersonData,
+  restorePersonData,
+  hardDeletePersonData,
+} from '../lib/firestore'
+
+const PERSON = 'dad'
+
+const COLLECTION_LABELS = {
+  medications: 'Medications',
+  appointments: 'Appointments',
+  tasks: 'Tasks',
+  careTeam: 'Care Team',
+  hospitalStays: 'Hospital Stays',
+}
+
+export default function DataManagementView() {
+  const [counts, setCounts] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [message, setMessage] = useState(null)
+  const [confirmText, setConfirmText] = useState('')
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      setCounts(await countPersonData(PERSON))
+    } catch (err) {
+      console.error('countPersonData error:', err)
+      setMessage({ type: 'error', text: 'Could not load data counts.' })
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  const totals = counts
+    ? Object.values(counts).reduce(
+        (acc, c) => ({ active: acc.active + c.active, deleted: acc.deleted + c.deleted }),
+        { active: 0, deleted: 0 }
+      )
+    : { active: 0, deleted: 0 }
+
+  async function run(label, fn, successText) {
+    setBusy(true)
+    setMessage(null)
+    try {
+      await fn(PERSON)
+      await refresh()
+      setMessage({ type: 'ok', text: successText })
+    } catch (err) {
+      console.error(`${label} error:`, err)
+      setMessage({ type: 'error', text: `${label} failed. Nothing may have been changed.` })
+    } finally {
+      setBusy(false)
+      setConfirmText('')
+    }
+  }
+
+  function onSoftDelete() {
+    if (!window.confirm(`Soft delete all of Dad's data (${totals.active} active records)? This hides it everywhere but can be restored from this screen.`)) return
+    run('Soft delete', softDeletePersonData, 'Soft deleted. Records are hidden but recoverable below.')
+  }
+
+  function onRestore() {
+    run('Restore', restorePersonData, 'Restored. Records are visible in the app again.')
+  }
+
+  function onHardDelete() {
+    if (confirmText !== 'DELETE') return
+    if (!window.confirm(`Permanently delete ALL of Dad's data (${totals.active + totals.deleted} records)? This CANNOT be undone.`)) return
+    run('Hard delete', hardDeletePersonData, 'Permanently deleted all of Dad’s data.')
+  }
+
+  return (
+    <div className="page">
+      <h2 style={{ margin: '0 0 6px', fontSize: 20, fontWeight: 700 }}>Manage Dad&rsquo;s Data</h2>
+      <p style={{ margin: '0 0 24px', color: 'var(--text2)', fontSize: 14, maxWidth: 560 }}>
+        Soft delete hides every record tagged to Dad across medications, appointments, tasks,
+        care team, and hospital stays &mdash; it can be undone here. Hard delete removes those
+        records permanently and cannot be undone.
+      </p>
+
+      {loading ? (
+        <p style={{ color: 'var(--text2)', fontSize: 14 }}>Loading&hellip;</p>
+      ) : (
+        <>
+          <div
+            style={{
+              border: '1px solid var(--border)',
+              borderRadius: 10,
+              overflow: 'hidden',
+              maxWidth: 560,
+              marginBottom: 24,
+            }}
+          >
+            {PERSON_COLLECTIONS.map((name, i) => {
+              const c = counts?.[name] || { active: 0, deleted: 0 }
+              return (
+                <div
+                  key={name}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    padding: '11px 16px',
+                    fontSize: 14,
+                    borderTop: i === 0 ? 'none' : '1px solid var(--border)',
+                  }}
+                >
+                  <span>{COLLECTION_LABELS[name] || name}</span>
+                  <span style={{ color: 'var(--text2)' }}>
+                    {c.active} active
+                    {c.deleted > 0 && (
+                      <span style={{ color: 'var(--red)' }}> &middot; {c.deleted} soft-deleted</span>
+                    )}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+
+          {message && (
+            <p
+              style={{
+                fontSize: 13,
+                marginBottom: 18,
+                color: message.type === 'error' ? 'var(--red)' : 'var(--text)',
+              }}
+            >
+              {message.text}
+            </p>
+          )}
+
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, marginBottom: 32 }}>
+            <button
+              className="btn-ghost"
+              disabled={busy || totals.active === 0}
+              onClick={onSoftDelete}
+            >
+              Soft delete all ({totals.active})
+            </button>
+            <button
+              className="btn-ghost"
+              disabled={busy || totals.deleted === 0}
+              onClick={onRestore}
+            >
+              Restore soft-deleted ({totals.deleted})
+            </button>
+          </div>
+
+          <div
+            style={{
+              border: '1px solid var(--red-border)',
+              background: 'var(--red-dim)',
+              borderRadius: 10,
+              padding: 18,
+              maxWidth: 560,
+            }}
+          >
+            <div style={{ fontWeight: 700, color: 'var(--red)', marginBottom: 6 }}>
+              Danger zone
+            </div>
+            <p style={{ margin: '0 0 14px', fontSize: 13, color: 'var(--text2)' }}>
+              Permanently delete all {totals.active + totals.deleted} of Dad&rsquo;s records
+              (including soft-deleted). This cannot be undone. Type{' '}
+              <strong>DELETE</strong> to enable the button.
+            </p>
+            <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+              <input
+                value={confirmText}
+                onChange={e => setConfirmText(e.target.value)}
+                placeholder="DELETE"
+                disabled={busy || totals.active + totals.deleted === 0}
+                style={{
+                  fontFamily: 'var(--ff)',
+                  fontSize: 13,
+                  padding: '8px 12px',
+                  borderRadius: 7,
+                  border: '1px solid var(--border2)',
+                  background: 'transparent',
+                  color: 'var(--text)',
+                }}
+              />
+              <button
+                onClick={onHardDelete}
+                disabled={busy || confirmText !== 'DELETE' || totals.active + totals.deleted === 0}
+                style={{
+                  fontFamily: 'var(--ff)',
+                  fontSize: 13,
+                  fontWeight: 600,
+                  padding: '8px 20px',
+                  borderRadius: 7,
+                  border: 'none',
+                  background: 'var(--red)',
+                  color: '#fff',
+                  cursor: confirmText === 'DELETE' && !busy ? 'pointer' : 'not-allowed',
+                  opacity: confirmText === 'DELETE' && !busy ? 1 : 0.5,
+                }}
+              >
+                Permanently delete everything
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/client/src/components/MainApp.jsx
+++ b/client/src/components/MainApp.jsx
@@ -23,6 +23,7 @@ import AskAiSheet from './chat/AskAiSheet'
 import HospitalView from './hospital/HospitalView'
 import NotificationBanner from './NotificationBanner'
 import BottomNav from './BottomNav'
+import DataManagementView from './DataManagementView'
 import { isFeatureEnabled } from '../lib/featureFlags'
 
 export function filterByPerson(items, personFilter) {
@@ -180,6 +181,10 @@ export default function MainApp({ user }) {
                       <span className="menu-item-label">Doctors</span>
                     </button>
                     <div className="menu-divider" />
+                    <button className="menu-item" onClick={() => { setActiveTab('data-admin'); setUserMenuOpen(false) }}>
+                      <span className="menu-item-label">Manage Dad&rsquo;s Data</span>
+                    </button>
+                    <div className="menu-divider" />
                     <button className="menu-item" onClick={() => { signOut(auth); setUserMenuOpen(false) }}>
                       Sign out
                     </button>
@@ -242,6 +247,12 @@ export default function MainApp({ user }) {
             <>
               <BackBar label="Hospital Stay" onBack={() => setActiveTab('dashboard')} />
               <HospitalView stays={stays} activeStay={activeStay} />
+            </>
+          )}
+          {activeTab === 'data-admin' && (
+            <>
+              <BackBar label="Manage Dad's Data" onBack={() => setActiveTab('dashboard')} />
+              <DataManagementView />
             </>
           )}
         </div>

--- a/client/src/hooks/useApts.js
+++ b/client/src/hooks/useApts.js
@@ -6,7 +6,7 @@ export function useApts() {
   const [apts, setApts] = useState([])
   useEffect(() => {
     return onSnapshot(collection(db, 'appointments'), snap => {
-      setApts(snap.docs.map(d => { const data = d.data(); return { ...data, person: data.person || 'dad' } }))
+      setApts(snap.docs.map(d => d.data()).filter(data => !data.deletedAt).map(data => ({ ...data, person: data.person || 'dad' })))
     }, err => console.error('Firestore apts error:', err))
   }, [])
   return apts

--- a/client/src/hooks/useCareTeam.js
+++ b/client/src/hooks/useCareTeam.js
@@ -6,7 +6,7 @@ export function useCareTeam() {
   const [careTeam, setCareTeam] = useState([])
   useEffect(() => {
     return onSnapshot(collection(db, 'careTeam'), snap => {
-      setCareTeam(snap.docs.map(d => { const data = d.data(); return { ...data, person: data.person || 'dad' } }))
+      setCareTeam(snap.docs.map(d => d.data()).filter(data => !data.deletedAt).map(data => ({ ...data, person: data.person || 'dad' })))
     }, err => console.error('Firestore careTeam error:', err))
   }, [])
   return careTeam

--- a/client/src/hooks/useHospitalStays.js
+++ b/client/src/hooks/useHospitalStays.js
@@ -7,7 +7,9 @@ export function useHospitalStays() {
   useEffect(() => {
     return onSnapshot(collection(db, 'hospitalStays'), snap => {
       const all = snap.docs
-        .map(d => ({ ...d.data(), person: d.data().person || 'dad' }))
+        .map(d => d.data())
+        .filter(data => !data.deletedAt)
+        .map(data => ({ ...data, person: data.person || 'dad' }))
         .sort((a, b) => b.admissionDate.localeCompare(a.admissionDate))
       setStays(all)
     }, err => console.error('Firestore hospitalStays error:', err))

--- a/client/src/hooks/useMeds.js
+++ b/client/src/hooks/useMeds.js
@@ -7,7 +7,7 @@ export function useMeds() {
   const [meds, setMeds] = useState([])
   useEffect(() => {
     return onSnapshot(collection(db, 'medications'), snap => {
-      const docs = snap.docs.map(d => { const data = d.data(); return { ...data, person: data.person || 'dad' } })
+      const docs = snap.docs.map(d => d.data()).filter(data => !data.deletedAt).map(data => ({ ...data, person: data.person || 'dad' }))
       setMeds(docs)
 
       // One-time migration: seed fills[] from top-level fields for pre-feature meds

--- a/client/src/hooks/useTasks.js
+++ b/client/src/hooks/useTasks.js
@@ -6,7 +6,7 @@ export function useTasks() {
   const [tasks, setTasks] = useState([])
   useEffect(() => {
     return onSnapshot(collection(db, 'tasks'), snap => {
-      setTasks(snap.docs.map(d => { const data = d.data(); return { ...data, person: data.person || 'dad' } }))
+      setTasks(snap.docs.map(d => d.data()).filter(data => !data.deletedAt).map(data => ({ ...data, person: data.person || 'dad' })))
     }, err => console.error('Firestore tasks error:', err))
   }, [])
   return tasks

--- a/client/src/lib/firestore.js
+++ b/client/src/lib/firestore.js
@@ -612,6 +612,61 @@ export async function updateStayTeamMember(stayId, oldMember, updates) {
   await updateDoc(ref, { stayTeam: arrayUnion(updated), updatedAt: new Date().toISOString() })
 }
 
+// Collections whose documents carry a `person` field (default 'dad' when absent).
+export const PERSON_COLLECTIONS = ['medications', 'appointments', 'tasks', 'careTeam', 'hospitalStays']
+
+function docPerson(data) {
+  return data.person || 'dad'
+}
+
+async function forEachPersonDoc(person, fn) {
+  for (const name of PERSON_COLLECTIONS) {
+    const snap = await getDocs(collection(db, name))
+    const matches = snap.docs.filter(d => docPerson(d.data()) === person)
+    for (let i = 0; i < matches.length; i += 400) {
+      const batch = writeBatch(db)
+      matches.slice(i, i + 400).forEach(d => fn(batch, name, d))
+      await batch.commit()
+    }
+  }
+}
+
+// Returns { collection: { active, deleted } } counts for the given person.
+export async function countPersonData(person) {
+  const result = {}
+  for (const name of PERSON_COLLECTIONS) {
+    const snap = await getDocs(collection(db, name))
+    const mine = snap.docs.filter(d => docPerson(d.data()) === person)
+    result[name] = {
+      active: mine.filter(d => !d.data().deletedAt).length,
+      deleted: mine.filter(d => d.data().deletedAt).length,
+    }
+  }
+  return result
+}
+
+// Soft delete: mark every active record for `person` with a deletedAt timestamp.
+export async function softDeletePersonData(person) {
+  const ts = new Date().toISOString()
+  await forEachPersonDoc(person, (batch, name, d) => {
+    if (!d.data().deletedAt) batch.update(doc(db, name, d.id), { deletedAt: ts })
+  })
+}
+
+// Restore: clear deletedAt on every soft-deleted record for `person`.
+export async function restorePersonData(person) {
+  await forEachPersonDoc(person, (batch, name, d) => {
+    if (d.data().deletedAt) batch.update(doc(db, name, d.id), { deletedAt: deleteField() })
+  })
+}
+
+// Hard delete: permanently remove every record for `person` (active or soft-deleted).
+export async function hardDeletePersonData(person) {
+  await forEachPersonDoc(person, (batch, name, d) => {
+    batch.delete(doc(db, name, d.id))
+  })
+}
+
 export async function importMeds(file, existingMeds) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()


### PR DESCRIPTION
## Summary
Adds a **Manage Dad's Data** section reachable from the profile dropdown that can soft-delete or permanently hard-delete all of Dad's records.

## Changes
- **New `DataManagementView.jsx`**: per-collection counts (active / soft-deleted), "Soft delete all", "Restore soft-deleted", and a type-`DELETE`-to-confirm "Danger zone" hard delete.
- **`firestore.js`**: `PERSON_COLLECTIONS` + `countPersonData`, `softDeletePersonData`, `restorePersonData`, `hardDeletePersonData`. Operates on records where `person === 'dad'` (records with no `person` field count as `dad`, matching the app default); batched at 400 ops/commit.
- **`MainApp.jsx`**: "Manage Dad's Data" dropdown item + `data-admin` route/view with back bar.
- **Data hooks** (`useMeds`, `useApts`, `useTasks`, `useCareTeam`, `useHospitalStays`): filter out `deletedAt` records so soft-deleted data disappears app-wide.

## Behavior
- **Soft delete** stamps `deletedAt` on every Dad-tagged record across medications, appointments, tasks, care team, and hospital stays. Hidden everywhere but restorable from this same screen.
- **Hard delete** permanently removes those records (active + soft-deleted) behind a type-to-confirm gate plus a confirm dialog. Irreversible.
- Scope is person-tagged records only — Mom's data and field-less collections (clinical notes, timeline) are untouched.

## Testing
- Production build passes; ESLint clean on all new/changed code; unit tests pass (71).
- e2e (`npm run test:e2e`) could not be run in this environment — Playwright's Chromium binary isn't installed and can't be downloaded here. Dev server + Firebase emulator both start healthy, so this is an environment limitation, not a code issue.

https://claude.ai/code/session_01JbXtmADAeZJtQJ5rDRvpBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbXtmADAeZJtQJ5rDRvpBE)_